### PR TITLE
SSH: added SLES support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This module has been tested to work on the following systems.
 
  * EL 5
  * EL 6
+ * SLES 11
 
 ===
 
@@ -169,3 +170,10 @@ ssh::keys:
     user: root
 </pre>
 
+===
+
+# Suse specific Hiera settings:
+
+<pre>
+ssh::packages: openssh
+</pre>

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,19 +1,6 @@
-# == Class: ssh
+# ## Class: ssh ##
 #
 # Manage ssh client and server.
-#
-# Sample usage:
-# # Push authorized key "root_for_userX" and remove key "root_for_userY" with hiera
-#
-# ssh::keys:
-#   root_for_userX:
-#     ensure: present
-#     user: root
-#     type: dsa
-#     key: AAAA...==
-#   root_for_userY:
-#     ensure: absent
-#     user: root
 #
 class ssh (
   $packages                = ['openssh-server',

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -119,4 +119,8 @@ X11Forwarding yes
 ##Banner /etc/motd
 
 # override default of no subsystems
-Subsystem	sftp	/usr/libexec/openssh/sftp-server
+<% if operatingsystem =~ /RedHat|CentOS/ -%>
+Subsystem       sftp    /usr/libexec/openssh/sftp-server
+<% elsif operatingsystem =~ /SLED|SLES/ -%>
+Subsystem       sftp    /usr/lib64/ssh/sftp-server
+<% end -%>


### PR DESCRIPTION
SLES support for SSH module.
Added Hiera example to README.md
Removed example for ssh::keys from init.pp, it's already in README.md

Functionality was tested under SLES 11.SP2
