### PR TITLE
ssh_config_hash_known_hosts option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ This module has been tested to work on the following systems with Puppet v3.
 
 # Parameters #
 
+ssh_config_hash_known_hosts
+---------------------------
+HashKnownHosts in ssh_config.
+Indicates that ssh should hash host names and addresses when they are added to ~/.ssh/known_hosts.
+These hashed names may be used normally by ssh and sshd, but they do not reveal identifying
+information should the file's contents be disclosed.  The default is 'no'.
+
+Note that existing names and addresses in known hosts files will not be converted automatically,
+but may be manually hashed using ssh-keygen. Use of this option may break facilities such as
+tab-completion that rely on being able to read unhashed host names from ~/.ssh/known_hosts.
+
+- *Default*: 'no'
+
 ssh_config_path
 ---------------
 Path to ssh_config.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class ssh (
   $permit_root_login                = 'yes',
   $purge_keys                       = 'true',
   $manage_firewall                  = false,
+  $ssh_config_hash_known_hosts      = 'no',
   $ssh_config_path                  = '/etc/ssh/ssh_config',
   $ssh_config_owner                 = 'root',
   $ssh_config_group                 = 'root',
@@ -46,6 +47,7 @@ class ssh (
 ) {
 
   # validate params
+  validate_re($ssh_config_hash_known_hosts, '^(yes|no)$', "ssh_config_hash_known_hosts may be either 'yes' or 'no' and is set to <${ssh_config_hash_known_hosts}>.")
   validate_re($sshd_config_port, '^\d+$', "sshd_config_port must be a valid number and is set to <${sshd_config_port}>")
   validate_re($sshd_password_authentication, '^(yes|no)$', "sshd_password_authentication may be either 'yes' or 'no' and is set to <${sshd_password_authentication}>.")
   validate_re($sshd_allow_tcp_forwarding, '^(yes|no)$', "sshd_allow_tcp_forwarding may be either 'yes' or 'no' and is set to <${sshd_allow_tcp_forwarding}>.")

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -33,6 +33,7 @@ describe 'ssh' do
 
     it { should contain_file('ssh_config').with_content(/^# This file is being maintained by Puppet.\n# DO NOT EDIT\n\n# \$OpenBSD: ssh_config,v 1.21 2005\/12\/06 22:38:27 reyk Exp \$/) }
     it { should contain_file('ssh_config').with_content(/^   Protocol 2$/) }
+    it { should contain_file('ssh_config').with_content(/^   HashKnownHosts no$/) }
 
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardAgent$/) }
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardX11$/) }
@@ -115,6 +116,7 @@ describe 'ssh' do
 
     it { should contain_file('ssh_config').with_content(/^# This file is being maintained by Puppet.\n# DO NOT EDIT\n\n# \$OpenBSD: ssh_config,v 1.21 2005\/12\/06 22:38:27 reyk Exp \$/) }
     it { should contain_file('ssh_config').with_content(/^   Protocol 2$/) }
+    it { should contain_file('ssh_config').with_content(/^   HashKnownHosts no$/) }
 
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardAgent$/) }
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardX11$/) }
@@ -198,6 +200,7 @@ describe 'ssh' do
 
     it { should contain_file('ssh_config').with_content(/^# This file is being maintained by Puppet.\n# DO NOT EDIT\n\n# \$OpenBSD: ssh_config,v 1.21 2005\/12\/06 22:38:27 reyk Exp \$/) }
     it { should contain_file('ssh_config').with_content(/^   Protocol 2$/) }
+    it { should contain_file('ssh_config').with_content(/^   HashKnownHosts no$/) }
 
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardAgent$/) }
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardX11$/) }
@@ -281,6 +284,7 @@ describe 'ssh' do
 
     it { should contain_file('ssh_config').with_content(/^# This file is being maintained by Puppet.\n# DO NOT EDIT\n\n# \$OpenBSD: ssh_config,v 1.21 2005\/12\/06 22:38:27 reyk Exp \$/) }
     it { should contain_file('ssh_config').with_content(/^   Protocol 2$/) }
+    it { should contain_file('ssh_config').with_content(/^   HashKnownHosts no$/) }
 
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardAgent$/) }
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardX11$/) }
@@ -361,6 +365,7 @@ describe 'ssh' do
     end
     let :params do
       {
+        :ssh_config_hash_known_hosts      => 'yes',
         :ssh_config_forward_agent         => 'yes',
         :ssh_config_forward_x11           => 'yes',
         :ssh_config_server_alive_interval => '300',
@@ -381,6 +386,7 @@ describe 'ssh' do
 
     it { should contain_file('ssh_config').with_content(/^# This file is being maintained by Puppet.\n# DO NOT EDIT\n\n# \$OpenBSD: ssh_config,v 1.21 2005\/12\/06 22:38:27 reyk Exp \$/) }
     it { should contain_file('ssh_config').with_content(/^   Protocol 2$/) }
+    it { should contain_file('ssh_config').with_content(/^   HashKnownHosts yes$/) }
     it { should contain_file('ssh_config').with_content(/^  ForwardAgent yes$/) }
     it { should contain_file('ssh_config').with_content(/^  ForwardX11 yes$/) }
     it { should contain_file('ssh_config').with_content(/^  ServerAliveInterval 300$/) }
@@ -480,6 +486,25 @@ describe 'ssh' do
         'mode'    => '0600',
       })
     }
+  end
+
+  context 'with ssh_config_hash_known_hosts set to invalid value on valid osfamily' do
+    let :facts do
+      {
+        :fqdn      => 'monkey.example.com',
+        :osfamily  => 'RedHat',
+        :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='
+      }
+    end
+    let :params do
+      { :ssh_config_hash_known_hosts => 'invalid' }
+    end
+
+    it 'should fail' do
+      expect {
+        should include_class('ssh')
+      }.to raise_error(Puppet::Error,/ssh_config_hash_known_hosts may be either \'yes\' or \'no\' and is set to <invalid>./)
+    end
   end
 
   context 'with sshd_config_port not being a valid number' do

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -44,6 +44,8 @@
 #   Tunnel no
 #   TunnelDevice any:any
 #   PermitLocalCommand no
+#   HashKnownHosts no
+   HashKnownHosts <%= @ssh_config_hash_known_hosts %>
 Host *
   GSSAPIAuthentication yes
 # If this option is set to yes then remote X11 clients will have full access


### PR DESCRIPTION
HashKnownHosts option is used in Aachen regulary. This PR add the optional possibility to activate this feature.
