### PR TITLE
Support rspec-puppet v1.0.0

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -532,7 +532,7 @@ describe 'ssh' do
 
     it 'should fail' do
       expect {
-        should include_class('ssh')
+        should contain_class('ssh')
       }.to raise_error(Puppet::Error,/ssh_config_hash_known_hosts may be either \'yes\' or \'no\' and is set to <invalid>./)
     end
   end


### PR DESCRIPTION
include_class has been replaced with contain_class.
http://bombasticmonkey.com/2013/12/05/rspec-puppet-1.0.0/
