### PR TITLE
 Add ability to merge all found instances of ssh::keys in Hiera.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ This module has been tested to work on the following systems with Puppet v3.
 
 # Parameters #
 
+hiera_merge
+-----------
+Boolean to merges all found instances of ssh::keys in Hiera. This is useful for specifying
+SSH keys at different levels of the hierarchy and having them all included in the catalog.
+
+This will default to 'true' in future versions.
+
+- *Default*: false
+
 ssh_config_hash_known_hosts
 ---------------------------
 HashKnownHosts in ssh_config.

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -840,4 +840,49 @@ describe 'ssh' do
       }.to raise_error(Puppet::Error)
     end
   end
+
+  describe 'with hiera_merge parameter specified' do
+    context 'as a non-boolean' do
+      let(:params) { { :hiera_merge => 'not_a_boolean' } }
+      let(:facts) do
+        { :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '6',
+        }
+      end
+
+      it 'should fail' do
+        expect { should raise_error(Puppet::Error) }
+      end
+    end
+
+    ['true',true].each do |value|
+      context "as #{value}" do
+        let(:params) { { :hiera_merge => value } }
+        let(:facts) do
+          { :osfamily          => 'RedHat',
+            :lsbmajdistrelease => '6',
+          }
+        end
+
+        it { should compile.with_all_deps }
+
+        it { should contain_class('ssh') }
+      end
+    end
+
+    ['false',false].each do |value|
+      context "as #{value}" do
+        let(:params) { { :hiera_merge => value } }
+        let(:facts) do
+          { :osfamily          => 'RedHat',
+            :lsbmajdistrelease => '6',
+          }
+        end
+
+        it { should compile.with_all_deps }
+
+        it { should contain_class('ssh') }
+      end
+    end
+  end
 end


### PR DESCRIPTION
This patch uses hiera_hash to find all instances of ssh::keys. The
default for this is false, to preserve backward compatibility, but will
change to true in future versions.
