### PR TITLE
Add version dependency to firewall module to support Forge

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,5 +8,6 @@ fixtures:
       ref: 'v1.0.2'
     firewall:
       repo: 'git://github.com/puppetlabs/puppetlabs-firewall.git'
+      ref: '0.2.1'
   symlinks:
     ssh: "#{source_dir}"

--- a/Modulefile
+++ b/Modulefile
@@ -9,4 +9,4 @@ project_page 'https://github.com/ghoneycutt/puppet-module-ssh'
 
 dependency 'puppetlabs/stdlib',   '>= 3.2.0'
 dependency 'ghoneycutt/common',   '>= 1.0.2'
-dependency 'puppetlabs/firewall'
+dependency 'puppetlabs/firewall', '>= 0.2.1'


### PR DESCRIPTION
Without this commit the forge gives the following error.
"Oops, that didn't work The dependency 'puppetlabs/firewall' in the
metadata.json must have a 'version_requirement' key."
