### PR TITLE
Adding deep merge support for allow/deny of users and groups

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -365,22 +365,6 @@ class ssh (
     validate_array($sshd_config_macs)
   }
 
-  if $sshd_config_denyusers != undef {
-    validate_array($sshd_config_denyusers)
-  }
-
-  if $sshd_config_denygroups != undef {
-    validate_array($sshd_config_denygroups)
-  }
-
-  if $sshd_config_allowusers != undef {
-    validate_array($sshd_config_allowusers)
-  }
-
-  if $sshd_config_allowgroups != undef {
-    validate_array($sshd_config_allowgroups)
-  }
-
   if $ssh_config_hash_known_hosts_real != undef {
     validate_re($ssh_config_hash_known_hosts_real, '^(yes|no)$', "ssh::ssh_config_hash_known_hosts may be either 'yes' or 'no' and is set to <${ssh_config_hash_known_hosts_real}>.")
   }
@@ -494,6 +478,40 @@ class ssh (
     }
   }
 
+#enable hiera merging for allow groups and allow users
+  if $hiera_merge_real == true {
+    $real_sshd_config_denygroups = hiera_array('ssh::sshd_config_denygroups',  undef)
+    $real_sshd_config_denyusers = hiera_array('ssh::sshd_config_denyusers',  undef)
+    $real_sshd_config_allowgroups = hiera_array('ssh::sshd_config_allowgroups',  undef)
+    $real_sshd_config_allowusers = hiera_array('ssh::sshd_config_allowusers',  undef)
+    }
+  else{
+    $real_sshd_config_denygroups = $sshd_config_denygroups
+    $real_sshd_config_denyusers = $sshd_config_denyusers
+    $real_sshd_config_allowgroups = $sshd_config_allowgroups
+    $real_sshd_config_allowusers = $sshd_config_allowusers
+    }
+
+
+
+  if $real_sshd_config_denyusers != undef {
+    validate_array($real_sshd_config_denyusers)
+    }
+
+  if $real_sshd_config_denygroups != undef {
+    validate_array($real_sshd_config_denygroups)
+    }
+
+  if $real_sshd_config_allowusers != undef {
+    validate_array($real_sshd_config_allowusers)
+    }
+
+  if $real_sshd_config_allowgroups != undef {
+    validate_array($real_sshd_config_allowgroups)
+    }
+  
+  
+  
   package { $packages_real:
     ensure    => installed,
     source    => $ssh_package_source_real,

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -166,14 +166,14 @@ Ciphers <%= @sshd_config_ciphers.join(',') %>
 MACs <%= @sshd_config_macs.join(',') %>
 <% end -%>
 <% if @sshd_config_denyusers -%>
-DenyUsers <%= @sshd_config_denyusers.join(' ') %>
+DenyUsers <%= @real_sshd_config_denyusers.join(' ') %>
 <% end -%>
 <% if @sshd_config_denygroups -%>
-DenyGroups <%= @sshd_config_denygroups.join(' ') %>
+DenyGroups <%= @real_sshd_config_denygroups.join(' ') %>
 <% end -%>
 <% if @sshd_config_allowusers -%>
-AllowUsers <%= @sshd_config_allowusers.join(' ') %>
+AllowUsers <%= @real_sshd_config_allowusers.join(' ') %>
 <% end -%>
 <% if @sshd_config_allowgroups -%>
-AllowGroups <%= @sshd_config_allowgroups.join(' ') %>
+AllowGroups <%= @real_sshd_config_allowgroups.join(' ') %>
 <% end -%>


### PR DESCRIPTION
I needed to tweak this behavior for our local environment so that we could use deeper merge to layer the groups allowed to log in more directly.  Specifically our sysadmins are allowed to login in our 'common' file but individual servers have allowances for smaller subsets of users and groups.  It's a bit of a hack but automatic parameterizing forced me to move over to a 'real' variable for each in the template and init.pp file.

This should for example allow:
common.yaml:
ssh::sshd_config_allowusers: sysadmin

host.yaml:
ssh:sshd_config_allowusers:
- jilll
- jack

For a final allow users list of jill jack sysadmin.
