### PR TITLE
permit customization of sshd config loglevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ sshd_config's group.
 
 - *Default*: 'root'
 
+sshd_config_loglevel
+---------------------------
+LogLevel option in sshd_config. Acceptable values are QUIET, FATAL, ERROR, INFO, VERBOSE.
+
+*DEBUG, DEBUG1, DEBUG2, and DEBUG3* are permitted values for sshd, however [setting the logging level to DEBUG or higher violates the privacy of users](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man5/sshd_config.5?query=sshd_config) and should not be done unless manually debugging.
+
+- *Default*: 'INFO'
+
 sshd_config_mode
 ---------------
 sshd_config's mode. The default is '0600' on Linux and '0644' on Solaris.
@@ -187,7 +195,7 @@ Specifies whether sshd should check file modes and ownership of the user's files
 
 sshd_config_serverkeybits
 ----------------------------
-Defines the number of bits in the ephemeral protocol version 1 server key.  The minimum value is 512, and the default is 1024 except for Solaris default value is 768. 
+Defines the number of bits in the ephemeral protocol version 1 server key.  The minimum value is 512, and the default is 1024 except for Solaris default value is 768.
 
 - *Default*: '1024' except for Solaris which is '768'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@ class ssh (
   $sshd_config_path                 = '/etc/ssh/sshd_config',
   $sshd_config_owner                = 'root',
   $sshd_config_group                = 'root',
+  $sshd_config_loglevel             = 'INFO',
   $sshd_config_mode                 = 'USE_DEFAULTS',
   $sshd_config_port                 = '22',
   $sshd_config_syslog_facility      = 'AUTH',
@@ -493,6 +494,10 @@ class ssh (
       fail("ssh::purge_keys must be 'true' or 'false' and is <${purge_keys}>.")
     }
   }
+
+  #loglevel
+  $supported_loglevel_vals=['QUIET', 'FATAL', 'ERROR', 'INFO', 'VERBOSE']
+  validate_re($sshd_config_loglevel, $supported_loglevel_vals)
 
   package { $packages_real:
     ensure    => installed,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -59,6 +59,7 @@ describe 'ssh' do
 
     it { should contain_file('sshd_config').with_content(/^Port 22$/) }
     it { should contain_file('sshd_config').with_content(/^SyslogFacility AUTH$/) }
+    it { should contain_file('sshd_config').with_content(/^LogLevel INFO$/) }
     it { should contain_file('sshd_config').with_content(/^LoginGraceTime 120$/) }
     it { should contain_file('sshd_config').with_content(/^PermitRootLogin yes$/) }
     it { should contain_file('sshd_config').with_content(/^ChallengeResponseAuthentication yes$/) }
@@ -182,6 +183,7 @@ describe 'ssh' do
     }
 
     it { should contain_file('sshd_config').with_content(/^SyslogFacility AUTH$/) }
+    it { should contain_file('sshd_config').with_content(/^LogLevel INFO$/) }
     it { should contain_file('sshd_config').with_content(/^LoginGraceTime 120$/) }
     it { should contain_file('sshd_config').with_content(/^PermitRootLogin yes$/) }
     it { should contain_file('sshd_config').with_content(/^ChallengeResponseAuthentication yes$/) }
@@ -282,6 +284,7 @@ describe 'ssh' do
     }
 
     it { should contain_file('sshd_config').with_content(/^SyslogFacility AUTH$/) }
+    it { should contain_file('sshd_config').with_content(/^LogLevel INFO$/) }
     it { should contain_file('sshd_config').with_content(/^LoginGraceTime 120$/) }
     it { should contain_file('sshd_config').with_content(/^PermitRootLogin yes$/) }
     it { should contain_file('sshd_config').with_content(/^ChallengeResponseAuthentication yes$/) }
@@ -381,6 +384,7 @@ describe 'ssh' do
     }
 
     it { should contain_file('sshd_config').with_content(/^SyslogFacility AUTH$/) }
+    it { should contain_file('sshd_config').with_content(/^LogLevel INFO$/) }
     it { should contain_file('sshd_config').with_content(/^LoginGraceTime 120$/) }
     it { should contain_file('sshd_config').with_content(/^PermitRootLogin yes$/) }
     it { should contain_file('sshd_config').with_content(/^ChallengeResponseAuthentication yes$/) }
@@ -480,6 +484,7 @@ describe 'ssh' do
 
     it { should contain_file('sshd_config').with_content(/^Port 22$/) }
     it { should contain_file('sshd_config').with_content(/^SyslogFacility AUTH$/) }
+    it { should contain_file('sshd_config').with_content(/^LogLevel INFO$/) }
     it { should contain_file('sshd_config').with_content(/^LoginGraceTime 120$/) }
     it { should contain_file('sshd_config').with_content(/^PermitRootLogin yes$/) }
     it { should contain_file('sshd_config').with_content(/^ChallengeResponseAuthentication yes$/) }
@@ -586,6 +591,7 @@ describe 'ssh' do
 
     it { should contain_file('sshd_config').with_content(/^Port 22$/) }
     it { should contain_file('sshd_config').with_content(/^SyslogFacility AUTH$/) }
+    it { should contain_file('sshd_config').with_content(/^LogLevel INFO$/) }
     it { should contain_file('sshd_config').with_content(/^LoginGraceTime 120$/) }
     it { should contain_file('sshd_config').with_content(/^PermitRootLogin yes$/) }
     it { should contain_file('sshd_config').with_content(/^ChallengeResponseAuthentication yes$/) }
@@ -692,6 +698,7 @@ describe 'ssh' do
 
     it { should contain_file('sshd_config').with_content(/^Port 22$/) }
     it { should contain_file('sshd_config').with_content(/^SyslogFacility AUTH$/) }
+    it { should contain_file('sshd_config').with_content(/^LogLevel INFO$/) }
     it { should contain_file('sshd_config').with_content(/^LoginGraceTime 120$/) }
     it { should contain_file('sshd_config').with_content(/^PermitRootLogin yes$/) }
     it { should contain_file('sshd_config').with_content(/^ChallengeResponseAuthentication yes$/) }
@@ -885,6 +892,7 @@ describe 'ssh' do
 
     it { should contain_file('sshd_config').with_content(/^Port 22222$/) }
     it { should contain_file('sshd_config').with_content(/^SyslogFacility DAEMON$/) }
+    it { should contain_file('sshd_config').with_content(/^LogLevel INFO$/) }
     it { should contain_file('sshd_config').with_content(/^LoginGraceTime 60$/) }
     it { should contain_file('sshd_config').with_content(/^PermitRootLogin no$/) }
     it { should contain_file('sshd_config').with_content(/^ChallengeResponseAuthentication no$/) }
@@ -926,6 +934,37 @@ describe 'ssh' do
         'require' => ['Package[openssh-server]', 'Package[openssh-clients]'],
       })
     }
+  end
+
+  describe 'sshd_loglevel param' do
+    context 'when set to an invalid value' do
+      let :facts do
+        {
+          :fqdn      => 'monkey.example.com',
+          :osfamily  => 'RedHat',
+          :root_home => '/root',
+          :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='
+        }
+      end
+      let (:params) {{'sshd_config_loglevel' => 'BOGON'}}
+      it 'should fail' do
+        expect { subject }.to raise_error(Puppet::Error, /"BOGON" does not match/)
+      end
+    end
+    ['QUIET', 'FATAL', 'ERROR', 'INFO', 'VERBOSE'].each do |supported_val|
+      context "when set to #{supported_val}" do
+        let :facts do
+          {
+            :fqdn      => 'monkey.example.com',
+            :osfamily  => 'RedHat',
+            :root_home => '/root',
+            :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='
+          }
+        end
+        let (:params) {{ 'sshd_config_loglevel' => supported_val}}
+        it { should contain_file('sshd_config').with_content(/^LogLevel #{supported_val}$/) }
+      end
+    end
   end
 
   context 'with manage_root_ssh_config set to \'true\' on valid osfamily' do
@@ -1911,6 +1950,7 @@ describe 'ssh' do
       end
     end
   end
+
 
   describe 'with parameter ssh_sendenv specified' do
     ['true',true].each do |value|

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -38,6 +38,7 @@ ServerKeyBits <%= @sshd_config_serverkeybits_real %>
 #SyslogFacility AUTH
 SyslogFacility <%= @sshd_config_syslog_facility %>
 #LogLevel INFO
+LogLevel <%= @sshd_config_loglevel %>
 
 # Authentication:
 


### PR DESCRIPTION
This adds a new param which will allow the user to set the sshd configuration setting 'LogLevel' to
'QUIET', 'FATAL', 'ERROR', 'INFO', 'VERBOSE'

There are also debug options supported by sshd, but since each of those levels violate users' assumption of security, I didn't make them supported options. My belief on this is that by allowing those levels to be persisted longer via puppet, we'd be encouraging bad habits.
