### PR TITLE
Authorized keys command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,25 @@ Boolean to enable SendEnv options for specifying environment variables. Default 
 
 - *Default*: 'USE_DEFAULTS'
 
+sshd_config_authorized_keys_command
+----------------
+*Absolute path* If set, will set this to the value of the AuthorizedKeysCommand setting. This specifies a program to be used to look up the user’s public keys. See [the OpenSSH sshd_config manpage](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man5/sshd_config.5?query=sshd_config&sec=5&arch=i386) for details. When this parameter is set, this module will also perform actions based on the values of the `ssh::sshd_config_authorized_keys_command_user`,`ssh::manage_authorized_keys_command_user`, and `ssh::authorized_keys_command_script` parameters.
+
+sshd_config_authorized_keys_command_user
+----------------
+*string* If `ssh::sshd_config_authorized_keys_command` is set this will set the AuthorizedKeysCommandUser option in `sshd_config` to the username specified here.  See [the OpenSSH sshd_config manpage](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man5/sshd_config.5?query=sshd_config&sec=5&arch=i386) for details.
+
+manage_authorized_keys_command_user
+----------------
+*bool* If `ssh::sshd_config_authorized_keys_command` is set, this will determine if this module should create the username provided to the `ssh::sshd_config_authorized_keys_command_user` parameter.
+
+
+authorized_keys_command_script
+----------------
+*template path* If `ssh::sshd_config_authorized_keys_command` is set, this will set the template that's used to deploy the script which lives in the location specified to `ssh::sshd_config_authorized_keys_command`. If this is not set, it is assumed that this script is being deployed by something outside of this module.
+
+
+
 sshd_config_path
 ----------------
 Path to sshd_config.

--- a/README.md
+++ b/README.md
@@ -532,3 +532,28 @@ ssh::keys:
     ensure: absent
     user: root
 </pre>
+
+# Utilizing a custom authorized_keys_command
+The minimum configuration required to utilize a custom authorized_keys_command
+with this module is to set the `authorized_keys_command` parameter with the path
+the script resides.
+
+## Sample minimal configuration for an authorized_keys_command
+
+    ssh::authorized_keys_command: '/usr/local/sbin/keys.sh'
+
+If you wish puppet to manage the script, you must populate the
+`authorized_keys_command_script` parameter with the location of the template to
+use for the file. Otherwise, this module will assume the file is managed either
+by another module, or by some other process in your deployment paradigm. The
+[OpenBSD Manpage](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man5/sshd_config.5?query=sshd_config&sec=5&arch=i386) recommends utilizing a dedicated user for this
+purpose. This may be specified by populating the
+`sshd_config_authorized_keys_command_user` parameter. The specified user may
+additionally be managed by puppet via the `manage_authorized_keys_command_user`
+parameter. An example snippit of hieradata utilizing all of these features might
+look something like this:
+
+    ssh::authorized_keys_command_script:           'my_site_module/commandscript.erb'
+    ssh::authorized_keys_command:                  '/usr/local/sbin/keys.sh'
+    ssh::manage_authorized_keys_command_user:      true
+    ssh::sshd_config_authorized_keys_command_user: 'gozer'

--- a/README.md
+++ b/README.md
@@ -120,23 +120,29 @@ Boolean to enable SendEnv options for specifying environment variables. Default 
 - *Default*: 'USE_DEFAULTS'
 
 sshd_config_authorized_keys_command
-----------------
+-----------------------------------
 *Absolute path* If set, will set this to the value of the AuthorizedKeysCommand setting. This specifies a program to be used to look up the user’s public keys. See [the OpenSSH sshd_config manpage](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man5/sshd_config.5?query=sshd_config&sec=5&arch=i386) for details. When this parameter is set, this module will also perform actions based on the values of the `ssh::sshd_config_authorized_keys_command_user`,`ssh::manage_authorized_keys_command_user`, and `ssh::authorized_keys_command_script` parameters.
 
+- *Default*: undef
+
 sshd_config_authorized_keys_command_user
-----------------
+----------------------------------------
 *string* If `ssh::sshd_config_authorized_keys_command` is set this will set the AuthorizedKeysCommandUser option in `sshd_config` to the username specified here.  See [the OpenSSH sshd_config manpage](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man5/sshd_config.5?query=sshd_config&sec=5&arch=i386) for details.
 
+- *Default*: undef
+
 manage_authorized_keys_command_user
-----------------
+-----------------------------------
 *bool* If `ssh::sshd_config_authorized_keys_command` is set, this will determine if this module should create the username provided to the `ssh::sshd_config_authorized_keys_command_user` parameter.
 
 
+- *Default*: false
+
 authorized_keys_command_script
-----------------
+------------------------------
 *template path* If `ssh::sshd_config_authorized_keys_command` is set, this will set the template that's used to deploy the script which lives in the location specified to `ssh::sshd_config_authorized_keys_command`. If this is not set, it is assumed that this script is being deployed by something outside of this module.
 
-
+- *Default*: undef
 
 sshd_config_path
 ----------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@
 # Manage ssh client and server
 #
 class ssh (
+  $authorized_keys_command_script           = undef,
   $hiera_merge                              = false,
   $keys                                     = undef,
   $manage_authorized_keys_command_user      = false,
@@ -552,6 +553,7 @@ class ssh (
       validate_string($authorized_keys_command_script)
     }
     if $sshd_config_authorized_keys_command_user {
+      validate_string($sshd_config_authorized_keys_command_user)
       #we want to make sure that the AKCommand file's group ownership matches
       #this user so it can run it.
       $_command_group = $sshd_config_authorized_keys_command_user
@@ -575,6 +577,7 @@ class ssh (
     }
 
     if $manage_authorized_keys_command_user {
+      validate_string($sshd_config_authorized_keys_command_user)
       user{$sshd_config_authorized_keys_command_user:
         comment => 'authorized keys command user',
         ensure  => 'present',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,77 +3,80 @@
 # Manage ssh client and server
 #
 class ssh (
-  $hiera_merge                      = false,
-  $packages                         = 'USE_DEFAULTS',
-  $permit_root_login                = 'yes',
-  $purge_keys                       = 'true',
-  $manage_firewall                  = false,
-  $ssh_package_source               = 'USE_DEFAULTS',
-  $ssh_package_adminfile            = 'USE_DEFAULTS',
-  $ssh_config_hash_known_hosts      = 'USE_DEFAULTS',
-  $ssh_config_path                  = '/etc/ssh/ssh_config',
-  $ssh_config_owner                 = 'root',
-  $ssh_config_group                 = 'root',
-  $ssh_config_mode                  = '0644',
-  $ssh_config_forward_x11           = undef,
-  $ssh_config_forward_x11_trusted   = 'USE_DEFAULTS',
-  $ssh_config_forward_agent         = undef,
-  $ssh_config_server_alive_interval = undef,
-  $ssh_config_sendenv_xmodifiers    = false,
-  $ssh_config_ciphers               = undef,
-  $ssh_config_macs                  = undef,
-  $ssh_config_template              = 'ssh/ssh_config.erb',
-  $ssh_sendenv                      = 'USE_DEFAULTS',
-  $sshd_config_path                 = '/etc/ssh/sshd_config',
-  $sshd_config_owner                = 'root',
-  $sshd_config_group                = 'root',
-  $sshd_config_loglevel             = 'INFO',
-  $sshd_config_mode                 = 'USE_DEFAULTS',
-  $sshd_config_port                 = '22',
-  $sshd_config_syslog_facility      = 'AUTH',
-  $sshd_config_template             = 'ssh/sshd_config.erb',
-  $sshd_config_login_grace_time     = '120',
-  $sshd_config_challenge_resp_auth  = 'yes',
-  $sshd_config_print_motd           = 'yes',
-  $sshd_config_use_dns              = 'USE_DEFAULTS',
-  $sshd_config_authkey_location     = undef,
-  $sshd_config_strictmodes          = undef,
-  $sshd_config_serverkeybits        = 'USE_DEFAULTS',
-  $sshd_config_banner               = 'none',
-  $sshd_config_ciphers              = undef,
-  $sshd_config_macs                 = undef,
-  $sshd_config_denyusers            = undef,
-  $sshd_config_denygroups           = undef,
-  $sshd_config_allowusers           = undef,
-  $sshd_config_allowgroups          = undef,
-  $sshd_banner_content              = undef,
-  $sshd_banner_owner                = 'root',
-  $sshd_banner_group                = 'root',
-  $sshd_banner_mode                 = '0644',
-  $sshd_config_xauth_location       = 'USE_DEFAULTS',
-  $sshd_config_subsystem_sftp       = 'USE_DEFAULTS',
-  $sshd_password_authentication     = 'yes',
-  $sshd_allow_tcp_forwarding        = 'yes',
-  $sshd_x11_forwarding              = 'yes',
-  $sshd_use_pam                     = 'USE_DEFAULTS',
-  $sshd_client_alive_count_max      = '3',
-  $sshd_client_alive_interval       = '0',
-  $sshd_gssapiauthentication        = 'yes',
-  $sshd_gssapikeyexchange           = 'USE_DEFAULTS',
-  $sshd_pamauthenticationviakbdint  = 'USE_DEFAULTS',
-  $sshd_gssapicleanupcredentials    = 'USE_DEFAULTS',
-  $sshd_acceptenv                   = 'USE_DEFAULTS',
-  $service_ensure                   = 'running',
-  $service_name                     = 'USE_DEFAULTS',
-  $service_enable                   = 'true',
-  $service_hasrestart               = 'true',
-  $service_hasstatus                = 'USE_DEFAULTS',
-  $ssh_key_ensure                   = 'present',
-  $ssh_key_import                   = 'true',
-  $ssh_key_type                     = 'ssh-rsa',
-  $keys                             = undef,
-  $manage_root_ssh_config           = 'false',
-  $root_ssh_config_content          = "# This file is being maintained by Puppet.\n# DO NOT EDIT\n",
+  $hiera_merge                              = false,
+  $keys                                     = undef,
+  $manage_authorized_keys_command_user      = false,
+  $manage_firewall                          = false,
+  $manage_root_ssh_config                   = 'false',
+  $packages                                 = 'USE_DEFAULTS',
+  $permit_root_login                        = 'yes',
+  $purge_keys                               = 'true',
+  $root_ssh_config_content                  = "# This file is being maintained by Puppet.\n# DO NOT EDIT\n",
+  $service_enable                           = 'true',
+  $service_ensure                           = 'running',
+  $service_hasrestart                       = 'true',
+  $service_hasstatus                        = 'USE_DEFAULTS',
+  $service_name                             = 'USE_DEFAULTS',
+  $ssh_config_ciphers                       = undef,
+  $ssh_config_forward_agent                 = undef,
+  $ssh_config_forward_x11                   = undef,
+  $ssh_config_forward_x11_trusted           = 'USE_DEFAULTS',
+  $ssh_config_group                         = 'root',
+  $ssh_config_hash_known_hosts              = 'USE_DEFAULTS',
+  $ssh_config_macs                          = undef,
+  $ssh_config_mode                          = '0644',
+  $ssh_config_owner                         = 'root',
+  $ssh_config_path                          = '/etc/ssh/ssh_config',
+  $ssh_config_sendenv_xmodifiers            = false,
+  $ssh_config_server_alive_interval         = undef,
+  $ssh_config_template                      = 'ssh/ssh_config.erb',
+  $ssh_key_ensure                           = 'present',
+  $ssh_key_import                           = 'true',
+  $ssh_key_type                             = 'ssh-rsa',
+  $ssh_package_adminfile                    = 'USE_DEFAULTS',
+  $ssh_package_source                       = 'USE_DEFAULTS',
+  $ssh_sendenv                              = 'USE_DEFAULTS',
+  $sshd_acceptenv                           = 'USE_DEFAULTS',
+  $sshd_allow_tcp_forwarding                = 'yes',
+  $sshd_banner_content                      = undef,
+  $sshd_banner_group                        = 'root',
+  $sshd_banner_mode                         = '0644',
+  $sshd_banner_owner                        = 'root',
+  $sshd_client_alive_count_max              = '3',
+  $sshd_client_alive_interval               = '0',
+  $sshd_config_allowgroups                  = undef,
+  $sshd_config_allowusers                   = undef,
+  $sshd_config_authkey_location             = undef,
+  $sshd_config_authorized_keys_command      = undef,
+  $sshd_config_authorized_keys_command_user = undef,
+  $sshd_config_banner                       = 'none',
+  $sshd_config_challenge_resp_auth          = 'yes',
+  $sshd_config_ciphers                      = undef,
+  $sshd_config_denygroups                   = undef,
+  $sshd_config_denyusers                    = undef,
+  $sshd_config_group                        = 'root',
+  $sshd_config_login_grace_time             = '120',
+  $sshd_config_loglevel                     = 'INFO',
+  $sshd_config_macs                         = undef,
+  $sshd_config_mode                         = 'USE_DEFAULTS',
+  $sshd_config_owner                        = 'root',
+  $sshd_config_path                         = '/etc/ssh/sshd_config',
+  $sshd_config_port                         = '22',
+  $sshd_config_print_motd                   = 'yes',
+  $sshd_config_serverkeybits                = 'USE_DEFAULTS',
+  $sshd_config_strictmodes                  = undef,
+  $sshd_config_subsystem_sftp               = 'USE_DEFAULTS',
+  $sshd_config_syslog_facility              = 'AUTH',
+  $sshd_config_template                     = 'ssh/sshd_config.erb',
+  $sshd_config_use_dns                      = 'USE_DEFAULTS',
+  $sshd_config_xauth_location               = 'USE_DEFAULTS',
+  $sshd_gssapiauthentication                = 'yes',
+  $sshd_gssapicleanupcredentials            = 'USE_DEFAULTS',
+  $sshd_gssapikeyexchange                   = 'USE_DEFAULTS',
+  $sshd_pamauthenticationviakbdint          = 'USE_DEFAULTS',
+  $sshd_password_authentication             = 'yes',
+  $sshd_use_pam                             = 'USE_DEFAULTS',
+  $sshd_x11_forwarding                      = 'yes',
 ) {
 
   case $::osfamily {
@@ -368,6 +371,22 @@ class ssh (
     validate_array($sshd_config_macs)
   }
 
+  if $sshd_config_denyusers != undef {
+    validate_array($sshd_config_denyusers)
+  }
+
+  if $sshd_config_denygroups != undef {
+    validate_array($sshd_config_denygroups)
+  }
+
+  if $sshd_config_allowusers != undef {
+    validate_array($sshd_config_allowusers)
+  }
+
+  if $sshd_config_allowgroups != undef {
+    validate_array($sshd_config_allowgroups)
+  }
+
   if $ssh_config_hash_known_hosts_real != undef {
     validate_re($ssh_config_hash_known_hosts_real, '^(yes|no)$', "ssh::ssh_config_hash_known_hosts may be either 'yes' or 'no' and is set to <${ssh_config_hash_known_hosts_real}>.")
   }
@@ -520,6 +539,49 @@ class ssh (
   if $real_sshd_config_allowgroups != undef {
     validate_array($real_sshd_config_allowgroups)
   }
+
+
+  #authorized_keys_command logic
+  if $sshd_config_authorized_keys_command {
+    #validate our input
+    validate_absolute_path($sshd_config_authorized_keys_command)
+    validate_bool($manage_authorized_keys_command_user)
+
+    if $authorized_keys_command_script {
+      #we want to manage the command script from a template
+      validate_string($authorized_keys_command_script)
+    }
+    if $sshd_config_authorized_keys_command_user {
+      #we want to make sure that the AKCommand file's group ownership matches
+      #this user so it can run it.
+      $_command_group = $sshd_config_authorized_keys_command_user
+    } else {
+      $_command_group = 'root'
+    }
+    if ($manage_authorized_keys_command_user and ($sshd_config_authorized_keys_command_user == undef)) {
+      #we can't manage a nonexistent user.
+      fail("ssh::manage_authorized_keys_command_user is set to true, but ssh::sshd_config_authorized_keys_command_user is not set.")
+    }
+    #end of sanity checking. We appear sane. (ish)
+
+    if $authorized_keys_command_script {
+      #we want to lay down the scriptfile from a template
+      file{$sshd_config_authorized_keys_command:
+        owner   => 'root',
+        group   => $_command_group,
+        mode    => '0550',
+        content => template($authorized_keys_command_script)
+      }
+    }
+
+    if $manage_authorized_keys_command_user {
+      user{$sshd_config_authorized_keys_command_user:
+        comment => 'authorized keys command user',
+        ensure  => 'present',
+      }
+    }
+
+  }#end of authorized_keys_command logic
 
   package { $packages_real:
     ensure    => installed,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1605,6 +1605,126 @@ describe 'ssh' do
     }
   end
 
+  context 'when the sshd_config_authorized_keys_command is set' do
+    context 'with an invalid value' do
+      it 'should fail' do
+      end
+    end#invalid value
+
+    context 'with a valid value' do
+      it 'should set the AuthorizedKeysCommand configuration option in sshd_config' do
+      end
+      context 'and the ssh::authorized_keys_command_script is set' do
+
+        context 'invalid value'do
+          it 'should fail' do
+          end
+        end#invalid ssh::authorized_keys_command_script
+
+        context 'valid value' do
+          it 'should lay down the sshd_config_authorized_keys_command file from the specified template' do
+          end
+        end#valid ssh::authorized_keys_command_script
+      end#ssh::authorized_keys_command_script set
+
+      context 'and the ssh::authorized_keys_command_script is not set' do
+
+        it 'should not lay down the sshd_config_authorized_keys_command file' do
+        end
+      end#ssh::authorized_keys_command_script not set
+
+      context 'and the manage_authorized_keys_command_user is true' do
+
+        context 'and the sshd_config_authorized_keys_command_user param is not set' do
+
+          it 'should fail' do
+          end
+        end#sshd_config_authorized_keys_command_user not set
+
+        context 'and the sshd_config_authorized_keys_command_user param is set' do
+
+          context 'with an invalid value' do
+          end#invalid sshd_config_authorized_keys_command_user
+
+          context 'with a valid value' do
+            it 'should set the AuthorizedKeysCommandUser configuration option in sshd_config' do
+            end
+          end#valid sshd_config_authorized_keys_command_user
+
+        end#sshd_config_authorized_keys_command_user set
+
+      end#manage_authorized_keys_command_user true
+
+      context 'and the manage_authorized_keys_command_user is false' do
+
+        context 'and the sshd_config_authorized_keys_command_user param is not set' do
+
+          it 'should not set the AuthorizedKeysCommandUser configuration option in sshd_config' do
+          end
+        end#sshd_config_authorized_keys_command_user not set
+
+        context 'and the sshd_config_authorized_keys_command_user param is set' do
+          context 'with an invalid value' do
+            it 'should not fail' do
+
+            end
+          end#invalid sshd_config_authorized_keys_command_user
+
+          context 'with a valid value' do
+            it 'should not contain the user' do
+            end
+            it 'should set the AuthorizedKeysCommandUser configuration option in sshd_config' do
+            end
+          end#valid sshd_config_authorized_keys_command_user
+
+        end#sshd_config_authorized_keys_command_user set
+
+      end#manage_authorized_keys_command_user false
+
+    end#valid sshd_config_authorized_keys_command set
+
+  end#sshd_config_authorized_keys_command set
+
+  context 'when the sshd_config_authorized_keys_command is not set' do
+    it 'should not set the AuthorizedKeysCommand configuration option in sshd_config' do
+    end
+
+    it 'should not set the AuthorizedKeysCommandUser configuration option in sshd_config' do
+    end
+
+    it 'should not contain the AuthorizedKeysCommand file resource' do
+      #fortunately, since it's never specified, it won't be in the manifest, so... groovy.
+    end
+    it 'should not create the user specified to the AuthorizedKeysCommandUser configuration option in sshd_config' do
+    end
+
+    context 'and the manage_authorized_keys_command_user is true' do
+      context 'and the sshd_config_authorized_keys_command_user param is not set' do
+        it 'not should fail'do
+        end
+      end#sshd_config_authorized_keys_command_user not set
+      context 'and the sshd_config_authorized_keys_command_user param is set' do
+        it 'should not create the user specified to the AuthorizedKeysCommandUser configuration option in sshd_config' do
+        end
+      end#sshd_config_authorized_keys_command_user set
+    end#manage_authorized_keys_command_user true
+    context 'and the manage_authorized_keys_command_user is false' do
+      context 'and the sshd_config_authorized_keys_command_user param is set' do
+        it 'should not create the user specified to the AuthorizedKeysCommandUser configuration option in sshd_config' do
+        end
+        it 'should not set the AuthorizedKeysCommandUser configuration option in sshd_config' do
+        end
+      end#sshd_config_authorized_keys_command_user set
+
+      context 'and the sshd_config_authorized_keys_command_user param is not set' do
+        it 'should not create the AuthorizedKeysCommandUser configuration option in sshd_config' do
+        end
+      end
+    end
+  end#sshd_config_authorized_keys_command NOT set
+
+
+
   context 'with keys specified as not of type hash' do
     let(:params) { { :keys => [ 'not', 'a', 'hash' ] } }
     let(:facts) { { :osfamily  => 'RedHat' } }

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -59,6 +59,15 @@ StrictModes <%= @sshd_config_strictmodes %>
 AuthorizedKeysFile <%= @sshd_config_authkey_location %>
 <% end -%>
 
+<% if @sshd_config_authorized_keys_command -%>
+#AuthorizedKeysCommand
+#http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man5/sshd_config.5?query=sshd_config&sec=5&arch=i386
+AuthorizedKeysCommand <%=@sshd_config_authorized_keys_command %>
+<%  if @sshd_config_authorized_keys_command_user -%>
+AuthorizedKeysCommandUser <%=@sshd_config_authorized_keys_command_user%>
+<%  end-%>
+<%end-%>
+
 # For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
 #RhostsRSAAuthentication no
 # similar for protocol version 2


### PR DESCRIPTION
This adds support for an AuthorizedKeysCommand script, and the AuthorizedKeysCommandUser

you can lay the file down by specifying the template to use, or handle the file resource outside of this module.

You can have this module manage the creation of the user resource, or you can handle it elsewhere. an assumption is made about group ownership of the AuthorizedKeysCommand script.

Please let me know if you'd like any changes in order to merge this.
