### PR TITLE
permit appending to ssh/sshd config files via params

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ This will default to 'true' in future versions.
 
 - *Default*: false
 
+ssh_config_appends
+-----------------
+
+- Populate with an *array*
+
+When populated, element will be appended to the end of the `ssh_config` file.
+
+- *Default*: undef
+
 ssh_config_hash_known_hosts
 ---------------------------
 HashKnownHosts in ssh_config.
@@ -112,6 +121,17 @@ ssh_sendenv
 Boolean to enable SendEnv options for specifying environment variables. Default is set to true on Linux.
 
 - *Default*: 'USE_DEFAULTS'
+
+
+sshd_config_appends
+-----------------
+
+- Populate with an *array*
+
+When populated, element will be appended to the end of the `sshd_config` file.
+
+- *Default*: undef
+
 
 sshd_config_path
 ----------------

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ssh_config_appends
 
 - Populate with an *array*
 
-When populated, element will be appended to the end of the `ssh_config` file.
+When populated, element will be appended to the end of the `ssh_config` file. A value of `undef` or `false` will disable this feature.
 
 - *Default*: undef
 
@@ -128,7 +128,7 @@ sshd_config_appends
 
 - Populate with an *array*
 
-When populated, element will be appended to the end of the `sshd_config` file.
+When populated, element will be appended to the end of the `sshd_config` file. A value of `undef` or `false` will disable this feature.
 
 - *Default*: undef
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class ssh (
   $manage_firewall                  = false,
   $ssh_package_source               = 'USE_DEFAULTS',
   $ssh_package_adminfile            = 'USE_DEFAULTS',
+  $ssh_config_appends               = undef,
   $ssh_config_hash_known_hosts      = 'USE_DEFAULTS',
   $ssh_config_path                  = '/etc/ssh/ssh_config',
   $ssh_config_owner                 = 'root',
@@ -23,6 +24,7 @@ class ssh (
   $ssh_config_ciphers               = undef,
   $ssh_config_macs                  = undef,
   $ssh_sendenv                      = 'USE_DEFAULTS',
+  $sshd_config_appends              = undef,
   $sshd_config_path                 = '/etc/ssh/sshd_config',
   $sshd_config_owner                = 'root',
   $sshd_config_group                = 'root',
@@ -477,6 +479,16 @@ class ssh (
     default: {
       fail("ssh::purge_keys must be 'true' or 'false' and is <${purge_keys}>.")
     }
+  }
+
+  #ssh_config_appends
+  if $ssh_config_appends {
+    validate_array($ssh_config_appends)
+  }
+
+  #sshd_config_appends
+  if $sshd_config_appends {
+    validate_array($sshd_config_appends)
   }
 
   #loglevel

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -936,6 +936,40 @@ describe 'ssh' do
     }
   end
 
+  describe 'ssh_config_appends parameter' do
+    context 'when populated with an invalid value' do
+      let (:facts) {{ :fqdn => 'monkey.example.com', :osfamily  => 'RedHat', :root_home => '/root', :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='}}
+      let (:params) {{ 'ssh_config_appends' => 'BOGON'}}
+      it 'should fail' do
+        expect { subject }.to raise_error(Puppet::Error, /not an Array/)
+      end
+    end
+    context 'when populated with a valid value' do
+      let (:facts) {{ :fqdn => 'monkey.example.com', :osfamily  => 'RedHat', :root_home => '/root', :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='}}
+      let (:params) {{ 'ssh_config_appends' => ['BOGON_ssh_one','BOGON_ssh_two']}}
+      it 'should update ssh_config, appending each element as its own line.' do
+        should contain_file('ssh_config').with_content(/^BOGON_ssh_one$/).with_content(/^BOGON_ssh_two$/)
+      end
+    end
+  end
+
+  describe 'sshd_config_appends parameter' do
+    context 'when populated with an invalid value' do
+      let (:facts) {{ :fqdn => 'monkey.example.com', :osfamily  => 'RedHat', :root_home => '/root', :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='}}
+      let (:params) {{ 'sshd_config_appends' => 'BOGON'}}
+      it 'should fail' do
+        expect { subject }.to raise_error(Puppet::Error, /not an Array/)
+      end
+    end
+    context 'when populated with a valid value' do
+      let (:facts) {{ :fqdn => 'monkey.example.com', :osfamily  => 'RedHat', :root_home => '/root', :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='}}
+      let (:params) {{ 'sshd_config_appends' => ['BOGON_sshd_one','BOGON_sshd_two']}}
+      it 'should update sshd_config, appending each element as its own line.' do
+        should contain_file('sshd_config').with_content(/^BOGON_sshd_one$/).with_content(/^BOGON_sshd_two$/)
+      end
+    end
+  end
+
   describe 'sshd_loglevel param' do
     context 'when set to an invalid value' do
       let :facts do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -944,11 +944,18 @@ describe 'ssh' do
         expect { subject }.to raise_error(Puppet::Error, /not an Array/)
       end
     end
+    context 'when unpopulated' do
+      let (:facts) {{ :fqdn => 'monkey.example.com', :osfamily  => 'RedHat', :root_home => '/root', :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='}}
+      let (:params) {{ 'ssh_config_appends' => false}}
+      it 'should not modify ssh_config.' do
+        should contain_file('ssh_config').without_content(/#The following lines are managed by ssh::ssh_config_appends/)
+      end
+    end
     context 'when populated with a valid value' do
       let (:facts) {{ :fqdn => 'monkey.example.com', :osfamily  => 'RedHat', :root_home => '/root', :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='}}
       let (:params) {{ 'ssh_config_appends' => ['BOGON_ssh_one','BOGON_ssh_two']}}
       it 'should update ssh_config, appending each element as its own line.' do
-        should contain_file('ssh_config').with_content(/^BOGON_ssh_one$/).with_content(/^BOGON_ssh_two$/)
+        should contain_file('ssh_config').with_content(/#The following lines are managed by ssh::ssh_config_appends/).with_content(/^BOGON_ssh_one$/).with_content(/^BOGON_ssh_two$/)
       end
     end
   end
@@ -961,11 +968,18 @@ describe 'ssh' do
         expect { subject }.to raise_error(Puppet::Error, /not an Array/)
       end
     end
+    context 'when unpopulated' do
+      let (:facts) {{ :fqdn => 'monkey.example.com', :osfamily  => 'RedHat', :root_home => '/root', :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='}}
+      let (:params) {{ 'sshd_config_appends' => false}}
+      it 'should not modify sshd_config.' do
+        should contain_file('sshd_config').without_content(/#The following lines are managed by ssh::sshd_config_appends/)
+      end
+    end
     context 'when populated with a valid value' do
       let (:facts) {{ :fqdn => 'monkey.example.com', :osfamily  => 'RedHat', :root_home => '/root', :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='}}
       let (:params) {{ 'sshd_config_appends' => ['BOGON_sshd_one','BOGON_sshd_two']}}
       it 'should update sshd_config, appending each element as its own line.' do
-        should contain_file('sshd_config').with_content(/^BOGON_sshd_one$/).with_content(/^BOGON_sshd_two$/)
+        should contain_file('sshd_config').with_content(/#The following lines are managed by ssh::sshd_config_appends/).with_content(/^BOGON_sshd_one$/).with_content(/^BOGON_sshd_two$/)
       end
     end
   end

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -80,3 +80,8 @@ Host *
 <% if @ssh_config_macs -%>
   MACs <%= @ssh_config_macs.join(',') %>
 <% end -%>
+<% if @ssh_config_appends != nil -%>
+<% [scope.lookupvar('ssh_config_appends')].flatten.each do |append_line| -%>
+<%= append_line %>
+<%end -%>
+<%end -%>

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -80,7 +80,9 @@ Host *
 <% if @ssh_config_macs -%>
   MACs <%= @ssh_config_macs.join(',') %>
 <% end -%>
-<% if @ssh_config_appends != nil -%>
+<% if @ssh_config_appends and @ssh_config_appends != nil -%>
+#
+#The following lines are managed by ssh::ssh_config_appends
 <% [scope.lookupvar('ssh_config_appends')].flatten.each do |append_line| -%>
 <%= append_line %>
 <%end -%>

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -178,7 +178,9 @@ AllowUsers <%= @sshd_config_allowusers_real.join(' ') %>
 <% if @sshd_config_allowgroups -%>
 AllowGroups <%= @sshd_config_allowgroups_real.join(' ') %>
 <% end -%>
-<% if @sshd_config_appends != nil -%>
+<% if @sshd_config_appends and @sshd_config_appends != nil -%>
+#
+#The following lines are managed by ssh::sshd_config_appends
 <% [scope.lookupvar('sshd_config_appends')].flatten.each do |append_line| -%>
 <%= append_line %>
 <%end -%>

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -178,3 +178,8 @@ AllowUsers <%= @sshd_config_allowusers_real.join(' ') %>
 <% if @sshd_config_allowgroups -%>
 AllowGroups <%= @sshd_config_allowgroups_real.join(' ') %>
 <% end -%>
+<% if @sshd_config_appends != nil -%>
+<% [scope.lookupvar('sshd_config_appends')].flatten.each do |append_line| -%>
+<%= append_line %>
+<%end -%>
+<%end -%>


### PR DESCRIPTION
This adds the ability to populate an array **ssh::ssh_config_appends** with data which will be appended as arbitrary lines to the `ssh_config` file.
Similarly, to append arbitrary lines to the `sshd_config` file one can populate **ssh::sshd_config_appends** with an array.
