### PR TITLE
Add support for changing HostKey option

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ Specify location of authorized_keys file. Default is to not specify.
 
 sshd_config_hostkey
 ----------------------------
-Specify location of HostKey file. Default is specific to the sshd implementation, usually /etc/ssh/ssh_host_rsa_key and /etc/ssh/ssh_host_dsa_key
+Specify location of HostKey file. Default to use only /etc/ssh/ssh_host_rsa_key
 
-- *Default*: undef
+- *Default*: /etc/ssh/ssh_host_rsa_key
 
 sshd_config_strictmodes
 ----------------------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,7 +61,7 @@ class ssh (
   $sshd_pamauthenticationviakbdint  = 'USE_DEFAULTS',
   $sshd_gssapicleanupcredentials    = 'USE_DEFAULTS',
   $sshd_acceptenv                   = 'USE_DEFAULTS',
-  $sshd_config_hostkey              = undef,
+  $sshd_config_hostkey              = 'USE_DEFAULTS',
   $service_ensure                   = 'running',
   $service_name                     = 'USE_DEFAULTS',
   $service_enable                   = 'true',
@@ -96,6 +96,7 @@ class ssh (
       $default_sshd_acceptenv                  = true
       $default_service_hasstatus               = true
       $default_sshd_config_serverkeybits       = '1024'
+      $default_sshd_config_hostkey             = '/etc/ssh/ssh_host_rsa_key'
     }
     'Suse': {
       $default_packages                        = 'openssh'
@@ -115,6 +116,7 @@ class ssh (
       $default_sshd_acceptenv                  = true
       $default_service_hasstatus               = true
       $default_sshd_config_serverkeybits       = '1024'
+      $default_sshd_config_hostkey             = '/etc/ssh/ssh_host_rsa_key'
       case $::architecture {
         'x86_64': {
           $default_sshd_config_subsystem_sftp = '/usr/lib64/ssh/sftp-server'
@@ -147,6 +149,7 @@ class ssh (
       $default_sshd_acceptenv                  = true
       $default_service_hasstatus               = true
       $default_sshd_config_serverkeybits       = '1024'
+      $default_sshd_config_hostkey             = '/etc/ssh/ssh_host_rsa_key'
     }
     'Solaris': {
       $default_ssh_config_hash_known_hosts     = undef
@@ -163,6 +166,7 @@ class ssh (
       $default_sshd_acceptenv                  = false
       $default_sshd_config_serverkeybits       = '768'
       $default_ssh_package_adminfile           = undef
+      $default_sshd_config_hostkey             = '/etc/ssh/ssh_host_rsa_key'
       case $::kernelrelease {
         '5.11': {
           $default_packages              = ['network/ssh',
@@ -333,8 +337,11 @@ class ssh (
     }
   }
 
-  if $sshd_config_hostkey != undef {
-    validate_string($sshd_config_hostkey)
+  if $sshd_config_hostkey == 'USE_DEFAULTS' {
+    $sshd_config_hostkey_real = $default_sshd_config_hostkey
+  } else {
+    validate_absolute_path($sshd_config_hostkey)
+    $sshd_config_hostkey_real = $sshd_config_hostkey
   }
 
   if $service_hasstatus == 'USE_DEFAULTS' {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -77,7 +77,7 @@ describe 'ssh' do
     it { should contain_file('sshd_config').with_content(/^ClientAliveCountMax 3$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPIAuthentication yes$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPICleanupCredentials yes$/) }
-    it { should_not contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
+    it { should contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*PAMAuthenticationViaKBDInt yes$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*GSSAPIKeyExchange no$/) }
     it { should_not contain_file('sshd_config').with_content(/^AuthorizedKeysFile/) }
@@ -193,7 +193,7 @@ describe 'ssh' do
     it { should contain_file('sshd_config').with_content(/^Subsystem sftp \/usr\/lib\/ssh\/sftp-server$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPIAuthentication yes$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*GSSAPICleanupCredentials yes$/) }
-    it { should_not contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
+    it { should contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
     it { should contain_file('sshd_config').with_content(/^PAMAuthenticationViaKBDInt yes$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPIKeyExchange yes$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*AcceptEnv L.*$/) }
@@ -294,7 +294,7 @@ describe 'ssh' do
     it { should contain_file('sshd_config').with_content(/^Subsystem sftp \/usr\/lib\/ssh\/sftp-server$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPIAuthentication yes$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*GSSAPICleanupCredentials yes$/) }
-    it { should_not contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
+    it { should contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
     it { should contain_file('sshd_config').with_content(/^PAMAuthenticationViaKBDInt yes$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPIKeyExchange yes$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*AcceptEnv L.*$/) }
@@ -394,7 +394,7 @@ describe 'ssh' do
     it { should contain_file('sshd_config').with_content(/^Subsystem sftp \/usr\/lib\/ssh\/sftp-server$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPIAuthentication yes$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*GSSAPICleanupCredentials yes$/) }
-    it { should_not contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
+    it { should contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
     it { should contain_file('sshd_config').with_content(/^PAMAuthenticationViaKBDInt yes$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPIKeyExchange yes$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*AcceptEnv L.*$/) }
@@ -502,7 +502,7 @@ describe 'ssh' do
     it { should contain_file('sshd_config').with_content(/^ClientAliveCountMax 3$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPIAuthentication yes$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPICleanupCredentials yes$/) }
-    it { should_not contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
+    it { should contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*PAMAuthenticationViaKBDInt yes$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*GSSAPIKeyExchange yes$/) }
     it { should contain_file('sshd_config').with_content(/^AcceptEnv L.*$/) }
@@ -609,7 +609,7 @@ describe 'ssh' do
     it { should contain_file('sshd_config').with_content(/^ClientAliveCountMax 3$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPIAuthentication yes$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPICleanupCredentials yes$/) }
-    it { should_not contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
+    it { should contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*PAMAuthenticationViaKBDInt yes$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*GSSAPIKeyExchange yes$/) }
     it { should contain_file('sshd_config').with_content(/^AcceptEnv L.*$/) }
@@ -716,7 +716,7 @@ describe 'ssh' do
     it { should contain_file('sshd_config').with_content(/^ClientAliveCountMax 3$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPIAuthentication yes$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPICleanupCredentials yes$/) }
-    it { should_not contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
+    it { should contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*PAMAuthenticationViaKBDInt yes$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*GSSAPIKeyExchange yes$/) }
     it { should contain_file('sshd_config').with_content(/^AcceptEnv L.*$/) }
@@ -1404,7 +1404,7 @@ describe 'ssh' do
     it 'should fail' do
       expect {
         should contain_class('ssh')
-      }.to raise_error(Puppet::Error,/is not a string/)
+      }.to raise_error(Puppet::Error,/is not an absolute path/)
     end
   end
 

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -26,9 +26,7 @@ Protocol 2
 # HostKeys for protocol version 2
 #HostKey /etc/ssh/ssh_host_rsa_key
 #HostKey /etc/ssh/ssh_host_dsa_key
-<% if @sshd_config_hostkey -%>
-HostKey <%= @sshd_config_hostkey %>
-<% end -%>
+HostKey <%= @sshd_config_hostkey_real %>
 
 # Lifetime and size of ephemeral version 1 server key
 #KeyRegenerationInterval 1h


### PR DESCRIPTION
This is to make it possible to change the HostKey location in
sshd_config or to completely leave it out, falling back to the sshd
defaults of using both /etc/ssh/ssh_host_rsa_key and
/etc/ssh/ssh_host_dsa_key.

As the HostKey is hardcoded to the template now it is currently not
possible to connect using for example ssh-dss. This commit changes that
behaviour.
