### PR TITLE
Add support for changing HostKey option

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ Specify location of authorized_keys file. Default is to not specify.
 
 - *Default*: undef
 
+sshd_config_hostkey
+----------------------------
+Specify an array of server side HostKey files to use. Default is to use only /etc/ssh/ssh_host_rsa_key
+
+- *Default*: /etc/ssh/ssh_host_rsa_key
+
 sshd_config_strictmodes
 ----------------------------
 Specifies whether sshd should check file modes and ownership of the user's files and home directory before accepting login. Valid values are yes and no.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,7 @@ class ssh (
   $sshd_pamauthenticationviakbdint  = 'USE_DEFAULTS',
   $sshd_gssapicleanupcredentials    = 'USE_DEFAULTS',
   $sshd_acceptenv                   = 'USE_DEFAULTS',
+  $sshd_config_hostkey              = 'USE_DEFAULTS',
   $service_ensure                   = 'running',
   $service_name                     = 'USE_DEFAULTS',
   $service_enable                   = 'true',
@@ -95,6 +96,7 @@ class ssh (
       $default_sshd_acceptenv                  = true
       $default_service_hasstatus               = true
       $default_sshd_config_serverkeybits       = '1024'
+      $default_sshd_config_hostkey             = [ '/etc/ssh/ssh_host_rsa_key' ]
     }
     'Suse': {
       $default_packages                        = 'openssh'
@@ -114,6 +116,7 @@ class ssh (
       $default_sshd_acceptenv                  = true
       $default_service_hasstatus               = true
       $default_sshd_config_serverkeybits       = '1024'
+      $default_sshd_config_hostkey             = [ '/etc/ssh/ssh_host_rsa_key' ]
       case $::architecture {
         'x86_64': {
           $default_sshd_config_subsystem_sftp = '/usr/lib64/ssh/sftp-server'
@@ -146,6 +149,7 @@ class ssh (
       $default_sshd_acceptenv                  = true
       $default_service_hasstatus               = true
       $default_sshd_config_serverkeybits       = '1024'
+      $default_sshd_config_hostkey             = [ '/etc/ssh/ssh_host_rsa_key' ]
     }
     'Solaris': {
       $default_ssh_config_hash_known_hosts     = undef
@@ -162,6 +166,7 @@ class ssh (
       $default_sshd_acceptenv                  = false
       $default_sshd_config_serverkeybits       = '768'
       $default_ssh_package_adminfile           = undef
+      $default_sshd_config_hostkey             = [ '/etc/ssh/ssh_host_rsa_key' ]
       case $::kernelrelease {
         '5.11': {
           $default_packages              = ['network/ssh',
@@ -330,6 +335,14 @@ class ssh (
         fail('ssh::sshd_acceptenv type must be true or false.')
       }
     }
+  }
+
+  if $sshd_config_hostkey == 'USE_DEFAULTS' {
+    $sshd_config_hostkey_real = $default_sshd_config_hostkey
+  } else {
+    validate_array($sshd_config_hostkey)
+    validate_absolute_path(join($sshd_config_hostkey))
+    $sshd_config_hostkey_real = $sshd_config_hostkey
   }
 
   if $service_hasstatus == 'USE_DEFAULTS' {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -850,6 +850,9 @@ describe 'ssh' do
         :sshd_config_serverkeybits       => '1024',
         :sshd_client_alive_count_max     => '0',
         :sshd_config_authkey_location    => '.ssh/authorized_keys',
+        :sshd_config_hostkey             => [ '/etc/ssh/ssh_host_rsa_key',
+                                              '/etc/ssh/ssh_host_dsa_key',
+        ],
         :sshd_config_strictmodes         => 'yes',
         :sshd_config_ciphers             => [ 'aes128-cbc',
                                               '3des-cbc',
@@ -910,11 +913,12 @@ describe 'ssh' do
     it { should contain_file('sshd_config').with_content(/^ClientAliveCountMax 0$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPIAuthentication yes$/) }
     it { should contain_file('sshd_config').with_content(/^GSSAPICleanupCredentials yes$/) }
-    it { should contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*PAMAuthenticationViaKBDInt yes$/) }
     it { should_not contain_file('sshd_config').with_content(/^\s*GSSAPIKeyExchange yes$/) }
     it { should contain_file('sshd_config').with_content(/^AcceptEnv L.*$/) }
     it { should contain_file('sshd_config').with_content(/^AuthorizedKeysFile .ssh\/authorized_keys/) }
+    it { should contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_rsa_key/) }
+    it { should contain_file('sshd_config').with_content(/^HostKey \/etc\/ssh\/ssh_host_dsa_key/) }
     it { should contain_file('sshd_config').with_content(/^StrictModes yes$/) }
     it { should contain_file('sshd_config').with_content(/^\s*Ciphers aes128-cbc,3des-cbc,blowfish-cbc,cast128-cbc,arcfour,aes192-cbc,aes256-cbc$/) }
     it { should contain_file('sshd_config').with_content(/^\s*MACs hmac-md5-etm@openssh.com,hmac-sha1-etm@openssh.com$/) }
@@ -1390,6 +1394,39 @@ describe 'ssh' do
       }.to raise_error(Puppet::Error,/is not a string/)
     end
   end
+
+  context 'with sshd_config_hostkey set to invalid value on valid osfamily' do
+    let(:params) { { :sshd_config_hostkey => false } }
+    let(:facts) do
+      { :fqdn      => 'monkey.example.com',
+        :osfamily  => 'RedHat',
+        :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='
+      }
+    end
+
+    it 'should fail' do
+      expect {
+        should contain_class('ssh')
+      }.to raise_error(Puppet::Error,/is not an Array/)
+    end
+  end
+
+  context 'with sshd_config_hostkey set to invalid path on valid osfamily' do
+    let(:params) { { :sshd_config_hostkey => ['not_a_path'] } }
+    let(:facts) do
+      { :fqdn      => 'monkey.example.com',
+        :osfamily  => 'RedHat',
+        :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='
+      }
+    end
+
+    it 'should fail' do
+      expect {
+        should contain_class('ssh')
+      }.to raise_error(Puppet::Error,/is not an absolute path./)
+    end
+  end
+
 
   context 'with sshd_config_strictmodes set to invalid value on valid osfamily' do
     let :facts do

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -24,8 +24,11 @@ Protocol 2
 # HostKey for protocol version 1
 #HostKey /etc/ssh/ssh_host_key
 # HostKeys for protocol version 2
-HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_rsa_key
 #HostKey /etc/ssh/ssh_host_dsa_key
+<% @sshd_config_hostkey_real.each do |hostkey| -%>
+HostKey <%= hostkey %>
+<% end -%>
 
 # Lifetime and size of ephemeral version 1 server key
 #KeyRegenerationInterval 1h


### PR DESCRIPTION
This is to make it possible to change the HostKey parameter in
sshd_config.

As the HostKey is hardcoded to the template now it is currently not
possible to connect using for example ssh-dss. This commit changes that
behaviour.

Please let me know if you have any suggestions or comments about the changes. I'm not sure if there's a more elegant way of doing the path validation.
