### PR TITLE
Release v3.19.1 - Bugfix: default GSSAPIDelegateCredentials to undef

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'ghoneycutt-ssh'
-version '3.19.0'
+version '3.19.1'
 source 'git://github.com/ghoneycutt/puppet-module-ssh.git'
 author 'ghoneycutt'
 license 'Apache License, Version 2.0'

--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ Boolean to enable SendEnv options for specifying environment variables. Default 
 
 - *Default*: 'USE_DEFAULTS'
 
+ssh_gssapidelegatecredentials
+-----------------------------
+*string* For GSSAPIDelegateCredentials setting in ssh_config. Valid values are
+'yes' and 'no' or to leave undef which will ensure the setting is not present
+in ssh_config.
+
+- *Default*: undef
+
 sshd_config_path
 ----------------
 Path to sshd_config.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,7 @@ class ssh (
   $ssh_config_macs                  = undef,
   $ssh_config_template              = 'ssh/ssh_config.erb',
   $ssh_sendenv                      = 'USE_DEFAULTS',
-  $ssh_gssapidelegatecredentials    = 'USE_DEFAULTS',
+  $ssh_gssapidelegatecredentials    = undef,
   $sshd_config_path                 = '/etc/ssh/sshd_config',
   $sshd_config_owner                = 'root',
   $sshd_config_group                = 'root',
@@ -87,7 +87,6 @@ class ssh (
       $default_ssh_package_source              = undef
       $default_ssh_package_adminfile           = undef
       $default_ssh_sendenv                     = true
-      $default_ssh_gssapidelegatecredentials   = undef
       $default_sshd_config_subsystem_sftp      = '/usr/libexec/openssh/sftp-server'
       $default_sshd_config_mode                = '0600'
       $default_sshd_config_use_dns             = 'yes'
@@ -107,7 +106,6 @@ class ssh (
       $default_ssh_package_source              = undef
       $default_ssh_package_adminfile           = undef
       $default_ssh_sendenv                     = true
-      $default_ssh_gssapidelegatecredentials   = undef
       $default_ssh_config_forward_x11_trusted  = 'yes'
       $default_sshd_config_mode                = '0600'
       $default_sshd_config_use_dns             = 'yes'
@@ -140,7 +138,6 @@ class ssh (
       $default_ssh_package_source              = undef
       $default_ssh_package_adminfile           = undef
       $default_ssh_sendenv                     = true
-      $default_ssh_gssapidelegatecredentials   = undef
       $default_sshd_config_subsystem_sftp      = '/usr/lib/openssh/sftp-server'
       $default_sshd_config_mode                = '0600'
       $default_sshd_config_use_dns             = 'yes'
@@ -176,7 +173,6 @@ class ssh (
           $default_service_name                  = 'ssh'
           $default_service_hasstatus             = true
           $default_ssh_package_source            = undef
-          $default_ssh_gssapidelegatecredentials = 'yes'
         }
         '5.10': {
           $default_packages                      = ['SUNWsshcu',
@@ -187,7 +183,6 @@ class ssh (
           $default_service_name                  = 'ssh'
           $default_service_hasstatus             = true
           $default_ssh_package_source            = '/var/spool/pkg'
-          $default_ssh_gssapidelegatecredentials = undef
         }
         '5.9' : {
           $default_packages                      = ['SUNWsshcu',
@@ -198,7 +193,6 @@ class ssh (
           $default_service_name                  = 'sshd'
           $default_service_hasstatus             = false
           $default_ssh_package_source            = '/var/spool/pkg'
-          $default_ssh_gssapidelegatecredentials = undef
         }
         default: {
           fail('ssh module supports Solaris kernel release 5.9, 5.10 and 5.11.')
@@ -324,13 +318,6 @@ class ssh (
     }
   }
 
-  if $ssh_gssapidelegatecredentials == 'USE_DEFAULTS' {
-    $ssh_gssapidelegatecredentials_real = $default_ssh_gssapidelegateredentials
-  } else {
-    $ssh_gssapidelegatecredentials_real = $ssh_gssapidelegatecredentials
-  }
-
-
   if $sshd_acceptenv == 'USE_DEFAULTS' {
     $sshd_acceptenv_real = $default_sshd_acceptenv
   } else {
@@ -405,8 +392,8 @@ class ssh (
     fail('ssh::sshd_config_banner must be set to be able to use sshd_banner_content.')
   }
 
-  if $ssh_gssapidelegatecredentials_real != undef {
-    validate_re($ssh_gssapidelegatecredentials_real, '^(yes|no)$', "ssh::ssh_gssapidelegatecredentials may be either 'yes' or 'no' and is set to <${ssh_gssapidelegatecredentials_real}>.")
+  if $ssh_gssapidelegatecredentials != undef {
+    validate_re($ssh_gssapidelegatecredentials, '^(yes|no)$', "ssh::ssh_gssapidelegatecredentials may be either 'yes' or 'no' and is set to <${ssh_gssapidelegatecredentials}>.")
   }
 
   if $sshd_gssapiauthentication != undef {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ghoneycutt-ssh",
-  "version": "3.19.0",
+  "version": "3.19.1",
   "author": "ghoneycutt",
   "summary": "Manages SSH",
   "license": "Apache License, Version 2.0",

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -53,8 +53,8 @@
 <% end -%>
 Host *
   GSSAPIAuthentication yes
-<% if @ssh_gssapidelegatecredentials_real != nil -%>  
-GSSAPIDelegateCredentials <%= @ssh_gssapidelegatecredentials_real %>
+<% if @ssh_gssapidelegatecredentials != nil -%>
+GSSAPIDelegateCredentials <%= @ssh_gssapidelegatecredentials %>
 <% end -%>
 # If this option is set to yes then remote X11 clients will have full access
 # to the original X11 display. As virtually no X11 client supports the untrusted


### PR DESCRIPTION
This was previously set to undef everywhere except Solaris 11 which was
set incorrectly to 'yes'.
