### PR TITLE
WIP: Do not export an empty sshkey before sshd installation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -658,10 +658,12 @@ class ssh (
   }
 
   # export each node's ssh key
-  @@sshkey { $::fqdn :
-    ensure => $ssh_key_ensure,
-    type   => $ssh_key_type,
-    key    => $key,
+  if is_string($key) {
+    @@sshkey { $::fqdn :
+      ensure => $ssh_key_ensure,
+      type   => $ssh_key_type,
+      key    => $key,
+    }
   }
 
   file { 'ssh_known_hosts':


### PR DESCRIPTION
This avoids problems before sshd is even installed.

I actually run into this while bootstrapping an OpenSuSE box with foreman, where no sshd is installed by default.

Still missing:
- tests
- (just for me: validation if a fresh installation on OpenSUSE actually works, got still problems with the AutoYaST there)

Feel free to comment :)
