### PR TITLE
Parameterize GSSAPIAuthentication in ssh_config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ Boolean to enable SendEnv options for specifying environment variables. Default 
 
 - *Default*: 'USE_DEFAULTS'
 
+ssh_gssapiauthentication
+-------------------------
+GSSAPIAuthentication: Enables/disables GSS-API user authentication in ssh_config. Valid values are 'yes' and 'no'.
+
+- *Default*: 'yes'
+
 ssh_gssapidelegatecredentials
 -----------------------------
 *string* For GSSAPIDelegateCredentials setting in ssh_config. Valid values are

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -422,9 +422,7 @@ class ssh (
     fail('ssh::sshd_config_banner must be set to be able to use sshd_banner_content.')
   }
 
-  if $ssh_gssapiauthentication != undef {
-    validate_re($ssh_gssapiauthentication, '^(yes|no)$', "ssh::ssh_gssapiauthentication may be either 'yes' or 'no' and is set to <${ssh_gssapiauthentication}>.")
-  }
+  validate_re($ssh_gssapiauthentication, '^(yes|no)$', "ssh::ssh_gssapiauthentication may be either 'yes' or 'no' and is set to <${ssh_gssapiauthentication}>.")
 
   if $ssh_gssapidelegatecredentials != undef {
     validate_re($ssh_gssapidelegatecredentials, '^(yes|no)$', "ssh::ssh_gssapidelegatecredentials may be either 'yes' or 'no' and is set to <${ssh_gssapidelegatecredentials}>.")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,7 @@ class ssh (
   $ssh_config_macs                     = undef,
   $ssh_config_template                 = 'ssh/ssh_config.erb',
   $ssh_sendenv                         = 'USE_DEFAULTS',
+  $ssh_gssapiauthentication            = 'yes',
   $ssh_gssapidelegatecredentials       = undef,
   $sshd_config_path                    = '/etc/ssh/sshd_config',
   $sshd_config_owner                   = 'root',
@@ -419,6 +420,10 @@ class ssh (
   }
   if $sshd_banner_content != undef and $sshd_config_banner == 'none' {
     fail('ssh::sshd_config_banner must be set to be able to use sshd_banner_content.')
+  }
+
+  if $ssh_gssapiauthentication != undef {
+    validate_re($ssh_gssapiauthentication, '^(yes|no)$', "ssh::ssh_gssapiauthentication may be either 'yes' or 'no' and is set to <${ssh_gssapiauthentication}>.")
   }
 
   if $ssh_gssapidelegatecredentials != undef {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2288,7 +2288,7 @@ describe 'ssh' do
         it do
           expect {
             should contain_class('ssh')
-          }.to raise_error(Puppet::Error,/^ssh::ssh_gssapiauthentication may be either 'yes' or 'no' and is set to <#{value.to_s}>./)
+          }.to raise_error(Puppet::Error,/^ssh::ssh_gssapiauthentication may be either 'yes' or 'no' and is set to <#{value.to_s}>\./)
         end
       end
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -55,6 +55,7 @@ describe 'ssh' do
         it { should contain_file('ssh_config').without_content(/^\s*Ciphers/) }
         it { should contain_file('ssh_config').without_content(/^\s*MACs/) }
         it { should contain_file('ssh_config').with_content(/^\s*GlobalKnownHostsFile \/etc\/ssh\/ssh_known_hosts$/) }
+        it { should contain_file('ssh_config').with_content(/^\s*GSSAPIAuthentication yes$/) }
 
         it { should_not contain_file('ssh_config').with_content(/^\s*ForwardAgent$/) }
         it { should_not contain_file('ssh_config').with_content(/^\s*ForwardX11$/) }
@@ -194,6 +195,7 @@ describe 'ssh' do
 
     it { should contain_file('ssh_config').with_content(/^# This file is being maintained by Puppet.\n# DO NOT EDIT\n\n# \$OpenBSD: ssh_config,v 1.21 2005\/12\/06 22:38:27 reyk Exp \$/) }
     it { should contain_file('ssh_config').with_content(/^   Protocol 2$/) }
+    it { should contain_file('ssh_config').with_content(/^\s*GSSAPIAuthentication yes$/) }
     it { should_not contain_file('ssh_config').with_content(/^\s*HashKnownHosts no$/) }
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardX11Trusted/) }
 
@@ -312,6 +314,7 @@ describe 'ssh' do
 
     it { should contain_file('ssh_config').with_content(/^# This file is being maintained by Puppet.\n# DO NOT EDIT\n\n# \$OpenBSD: ssh_config,v 1.21 2005\/12\/06 22:38:27 reyk Exp \$/) }
     it { should contain_file('ssh_config').with_content(/^   Protocol 2$/) }
+    it { should contain_file('ssh_config').with_content(/^\s*GSSAPIAuthentication yes$/) }
     it { should_not contain_file('ssh_config').with_content(/^\s*HashKnownHosts no$/) }
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardX11Trusted/) }
 
@@ -548,6 +551,7 @@ describe 'ssh' do
     it { should contain_file('ssh_config').with_content(/^\s*HashKnownHosts no$/) }
     it { should contain_file('ssh_config').with_content(/^\s*SendEnv L.*$/) }
     it { should contain_file('ssh_config').with_content(/^\s*ForwardX11Trusted yes$/) }
+    it { should contain_file('ssh_config').with_content(/^\s*GSSAPIAuthentication yes$/) }
 
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardAgent$/) }
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardX11$/) }
@@ -672,6 +676,7 @@ describe 'ssh' do
     it { should contain_file('ssh_config').with_content(/^\s*HashKnownHosts no$/) }
     it { should contain_file('ssh_config').with_content(/^\s*SendEnv L.*$/) }
     it { should contain_file('ssh_config').with_content(/^\s*ForwardX11Trusted yes$/) }
+    it { should contain_file('ssh_config').with_content(/^\s*GSSAPIAuthentication yes$/) }
 
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardAgent$/) }
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardX11$/) }
@@ -796,6 +801,7 @@ describe 'ssh' do
     it { should contain_file('ssh_config').with_content(/^\s*HashKnownHosts no$/) }
     it { should contain_file('ssh_config').with_content(/^\s*SendEnv L.*$/) }
     it { should contain_file('ssh_config').with_content(/^\s*ForwardX11Trusted yes$/) }
+    it { should contain_file('ssh_config').with_content(/^\s*GSSAPIAuthentication yes$/) }
 
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardAgent$/) }
     it { should_not contain_file('ssh_config').with_content(/^\s*ForwardX11$/) }
@@ -941,6 +947,7 @@ describe 'ssh' do
     it { should contain_file('ssh_config').with_content(/^\s*SendEnv L.*$/) }
     it { should contain_file('ssh_config').with_content(/^  ForwardAgent yes$/) }
     it { should contain_file('ssh_config').with_content(/^  ForwardX11 yes$/) }
+    it { should contain_file('ssh_config').with_content(/^\s*GSSAPIAuthentication yes$/) }
     it { should contain_file('ssh_config').with_content(/^  ServerAliveInterval 300$/) }
     it { should contain_file('ssh_config').with_content(/^  SendEnv XMODIFIERS$/) }
     it { should contain_file('ssh_config').with_content(/^\s*Ciphers aes128-cbc,3des-cbc,blowfish-cbc,cast128-cbc,arcfour,aes192-cbc,aes256-cbc$/) }
@@ -2249,6 +2256,39 @@ describe 'ssh' do
 
         it 'should fail' do
           expect { should raise_error(Puppet::Error,/^ssh::sshd_gssapidelegatecredentials may be either 'yes' or 'no' and is set to <#{value}>./) }
+        end
+      end
+    end
+  end
+
+  describe 'with parameter ssh_gssapiauthentication' do
+    let(:facts) do
+      { :fqdn      => 'monkey.example.com',
+        :osfamily  => 'RedHat',
+        :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='
+      }
+    end
+
+    ['yes','no'].each do |value|
+      context "specified as valid #{value} (as #{value.class})" do
+        let(:params) { { :ssh_gssapiauthentication => value } }
+
+        it { should contain_file('ssh_config').with_content(/^\s*GSSAPIAuthentication #{value}$/) }
+      end
+    end
+
+    ['YES',true,2.42,['array'],a = { 'ha' => 'sh' }].each do |value|
+      context "specified as invalid value #{value} (as #{value.class})" do
+        let(:params) { { :ssh_gssapiauthentication => value } }
+
+        if value.is_a?(Array)
+          value = value.join
+        end
+
+        it do
+          expect {
+            should contain_class('ssh')
+          }.to raise_error(Puppet::Error,/^ssh::ssh_gssapiauthentication may be either 'yes' or 'no' and is set to <#{value.to_s}>./)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,2 @@
+require 'rubygems'
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,1 @@
-require 'rubygems'
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -55,7 +55,8 @@
    GlobalKnownHostsFile <%= @ssh_config_global_known_hosts_file %>
 <% end -%>
 Host *
-  GSSAPIAuthentication yes
+#  GSSAPIAuthentication yes
+  GSSAPIAuthentication <%= @ssh_gssapiauthentication %>
 <% if @ssh_gssapidelegatecredentials != nil -%>
 GSSAPIDelegateCredentials <%= @ssh_gssapidelegatecredentials %>
 <% end -%>


### PR DESCRIPTION
Hi Garrett,

I wrote some codes to make GSSAPIAuthentication in ssh_config modifiable.
Meanwhile, I found a bug in the spec test code.
What ever I put after Puppet::Error in test code, it always passes the test.
Phil helped to fix the bug on the piece of my new tests.
But there are still defects on other lines.
I will try to fix all these lines and raise another pull request later.

Thanks!

BRs,
Kyle Fu