### PR TITLE
fix for hiera_array() always returning an empty array

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,10 +44,10 @@ class ssh (
   $sshd_config_banner                  = 'none',
   $sshd_config_ciphers                 = undef,
   $sshd_config_macs                    = undef,
-  $sshd_config_denyusers               = undef,
-  $sshd_config_denygroups              = undef,
-  $sshd_config_allowusers              = undef,
-  $sshd_config_allowgroups             = undef,
+  $sshd_config_allowgroups             = [],
+  $sshd_config_allowusers              = [],
+  $sshd_config_denygroups              = [],
+  $sshd_config_denyusers               = [],
   $sshd_config_maxstartups             = undef,
   $sshd_config_maxsessions             = undef,
   $sshd_config_chrootdirectory         = undef,
@@ -603,32 +603,32 @@ class ssh (
   $supported_loglevel_vals=['QUIET', 'FATAL', 'ERROR', 'INFO', 'VERBOSE']
   validate_re($sshd_config_loglevel, $supported_loglevel_vals)
 
-  #enable hiera merging for allow groups and allow users
+  #enable hiera merging for groups and users
   if $hiera_merge_real == true {
-    $sshd_config_denygroups_real  = hiera_array('ssh::sshd_config_denygroups',  undef)
-    $sshd_config_denyusers_real   = hiera_array('ssh::sshd_config_denyusers',  undef)
-    $sshd_config_allowgroups_real = hiera_array('ssh::sshd_config_allowgroups',  undef)
-    $sshd_config_allowusers_real  = hiera_array('ssh::sshd_config_allowusers',  undef)
+    $sshd_config_allowgroups_real = hiera_array('ssh::sshd_config_allowgroups',[])
+    $sshd_config_allowusers_real  = hiera_array('ssh::sshd_config_allowusers',[])
+    $sshd_config_denygroups_real  = hiera_array('ssh::sshd_config_denygroups',[])
+    $sshd_config_denyusers_real   = hiera_array('ssh::sshd_config_denyusers',[])
   } else {
-    $sshd_config_denygroups_real  = $sshd_config_denygroups
-    $sshd_config_denyusers_real   = $sshd_config_denyusers
     $sshd_config_allowgroups_real = $sshd_config_allowgroups
     $sshd_config_allowusers_real  = $sshd_config_allowusers
+    $sshd_config_denygroups_real  = $sshd_config_denygroups
+    $sshd_config_denyusers_real   = $sshd_config_denyusers
   }
 
-  if $sshd_config_denyusers_real != undef {
+  if $sshd_config_denyusers_real != [] {
     validate_array($sshd_config_denyusers_real)
   }
 
-  if $sshd_config_denygroups_real != undef {
+  if $sshd_config_denygroups_real != [] {
     validate_array($sshd_config_denygroups_real)
   }
 
-  if $sshd_config_allowusers_real != undef {
+  if $sshd_config_allowusers_real != [] {
     validate_array($sshd_config_allowusers_real)
   }
 
-  if $sshd_config_allowgroups_real != undef {
+  if $sshd_config_allowgroups_real != [] {
     validate_array($sshd_config_allowgroups_real)
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2086,7 +2086,7 @@ describe 'ssh' do
     end
 
     ['true',true].each do |value|
-      context "as #{value}" do
+      context "as #{value} with hiera data getting collected" do
         let(:params) { { :hiera_merge => value } }
         let(:facts) do
           { :osfamily          => 'RedHat',
@@ -2099,12 +2099,54 @@ describe 'ssh' do
 
         it { should contain_class('ssh') }
 
-        it { should contain_file('sshd_config').with_content(/^\s*DenyUsers denyuser_from_fqdn denyuser_from_common/) }
-        it { should contain_file('sshd_config').with_content(/^\s*DenyGroups denygroup_from_fqdn denygroup_from_common/) }
-        it { should contain_file('sshd_config').with_content(/^\s*AllowUsers allowuser_from_fqdn allowuser_from_common/) }
-        it { should contain_file('sshd_config').with_content(/^\s*AllowGroups allowgroup_from_fqdn allowgroup_from_common/) }
+        it { should contain_file('sshd_config').with_content(/^\s*DenyUsers denyuser_from_fqdn/) }
+        it { should contain_file('sshd_config').with_content(/^\s*DenyGroups denygroup_from_fqdn/) }
+        it { should contain_file('sshd_config').with_content(/^\s*AllowUsers allowuser_from_fqdn/) }
+        it { should contain_file('sshd_config').with_content(/^\s*AllowGroups allowgroup_from_fqdn/) }
 
       end
+    end
+
+    context "as true with with hiera data getting merged through levels" do
+      let(:params) { { :hiera_merge => true } }
+      let(:facts) do
+        { :osfamily          => 'RedHat',
+          :fqdn              => 'hieramerge.example.com',
+          :lsbmajdistrelease => '6',
+          :specific          => 'test_hiera_merge',
+        }
+      end
+
+      it { should compile.with_all_deps }
+
+      it { should contain_class('ssh') }
+
+      it { should contain_file('sshd_config').with_content(/^\s*DenyUsers denyuser_from_fqdn denyuser_from_fact/) }
+      it { should contain_file('sshd_config').with_content(/^\s*DenyGroups denygroup_from_fqdn denygroup_from_fact/) }
+      it { should contain_file('sshd_config').with_content(/^\s*AllowUsers allowuser_from_fqdn allowuser_from_fact/) }
+      it { should contain_file('sshd_config').with_content(/^\s*AllowGroups allowgroup_from_fqdn allowgroup_from_fact/) }
+
+    end
+
+    context "as true with no hiera data provided" do
+      let(:params) { { :hiera_merge => true } }
+      let(:facts) do
+        { :osfamily          => 'Suse',
+          :fqdn              => 'notinhiera.example.com',
+          :lsbmajdistrelease => '11',
+          :architecture      => 'x86_64',
+        }
+      end
+
+      it { should compile.with_all_deps }
+
+      it { should contain_class('ssh') }
+
+      it { should contain_file('sshd_config').without_content(/^\s*DenyUsers/) }
+      it { should contain_file('sshd_config').without_content(/^\s*DenyGroups/) }
+      it { should contain_file('sshd_config').without_content(/^\s*AllowUsers/) }
+      it { should contain_file('sshd_config').without_content(/^\s*AllowGroups/) }
+
     end
 
     ['false',false].each do |value|

--- a/spec/fixtures/hiera/hiera.yaml
+++ b/spec/fixtures/hiera/hiera.yaml
@@ -5,4 +5,4 @@
   :datadir: 'spec/fixtures/hiera/hieradata'
 :hierarchy:
   - fqdn/%{fqdn}
-  - common
+  - specific/%{specific}

--- a/spec/fixtures/hiera/hieradata/common.yaml
+++ b/spec/fixtures/hiera/hieradata/common.yaml
@@ -1,9 +1,0 @@
----
-ssh::sshd_config_allowgroups:
-  - allowgroup_from_common
-ssh::sshd_config_allowusers:
-  - allowuser_from_common
-ssh::sshd_config_denygroups:
-  - denygroup_from_common
-ssh::sshd_config_denyusers:
-  - denyuser_from_common

--- a/spec/fixtures/hiera/hieradata/specific/test_hiera_merge.yaml
+++ b/spec/fixtures/hiera/hieradata/specific/test_hiera_merge.yaml
@@ -1,5 +1,9 @@
 ---
 ssh::sshd_config_allowgroups:
+  - allowgroup_from_fact
 ssh::sshd_config_allowusers:
+  - allowuser_from_fact
 ssh::sshd_config_denygroups:
+  - denygroup_from_fact
 ssh::sshd_config_denyusers:
+  - denyuser_from_fact

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -200,16 +200,16 @@ Ciphers <%= @sshd_config_ciphers.join(',') %>
 <% if @sshd_config_macs -%>
 MACs <%= @sshd_config_macs.join(',') %>
 <% end -%>
-<% if @sshd_config_denyusers_real -%>
+<% if @sshd_config_denyusers_real != [] -%>
 DenyUsers <%= @sshd_config_denyusers_real.join(' ') %>
 <% end -%>
-<% if @sshd_config_denygroups_real -%>
+<% if @sshd_config_denygroups_real != [] -%>
 DenyGroups <%= @sshd_config_denygroups_real.join(' ') %>
 <% end -%>
-<% if @sshd_config_allowusers_real -%>
+<% if @sshd_config_allowusers_real != [] -%>
 AllowUsers <%= @sshd_config_allowusers_real.join(' ') %>
 <% end -%>
-<% if @sshd_config_allowgroups_real -%>
+<% if @sshd_config_allowgroups_real != [] -%>
 AllowGroups <%= @sshd_config_allowgroups_real.join(' ') %>
 <% end -%>
 <% if @sshd_config_match -%>


### PR DESCRIPTION
After fixing the used variable in my last commit, I came accross that hiera_array() always delivers an empty string instead of undef on Ruby 1.8.7 :(
<pre>Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse template ssh/sshd_config.erb:
  Filepath: /etc/puppet/environments/ssh/modules/ssh/templates/sshd_config.erb
  Line: 204
  Detail: undefined method `join' for "":String
 at /etc/puppet/environments/ssh/modules/ssh/manifests/init.pp:657 on node [redacted]
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
</pre>

With this patch the code will only by used when the variable contains an array. Adding a (silent) variable validation for free ;)
