### PR TITLE
sshd_config_match

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,12 +417,14 @@ Match directive is supported on SSH >= 5.x.
 
 - *Hiera example*:
 <pre>
+```yaml
 ssh::sshd_config_match:
   'User JohnDoe':
     - 'AllowTcpForwarding yes'
   'Address 2.4.2.0':
     - 'X11Forwarding yes'
     - 'PasswordAuthentication no'
+```
 </pre>
 
 keys

--- a/README.md
+++ b/README.md
@@ -416,7 +416,6 @@ Match directive is supported on SSH >= 5.x.
 - *Default*: undef
 
 - *Hiera example*:
-<pre>
 ```yaml
 ssh::sshd_config_match:
   'User JohnDoe':
@@ -425,7 +424,6 @@ ssh::sshd_config_match:
     - 'X11Forwarding yes'
     - 'PasswordAuthentication no'
 ```
-</pre>
 
 keys
 ----


### PR DESCRIPTION
Just a little improvement to update README.md to better display Hiera example for *sshd_config_match* directive using Github syntax highlight for YAML.