### PR TITLE
WIP - Add facts for ssh version

### DIFF
--- a/lib/facter/ssh.rb
+++ b/lib/facter/ssh.rb
@@ -1,0 +1,16 @@
+Facter.add('ssh_version') do
+  setcode do
+    if Facter::Util::Resolution.which('ssh')
+      Facter::Util::Resolution.exec('ssh -V 2>&1').match(/^[A-Za-z0-9._]+/)[0]
+    end
+  end
+end
+
+Facter.add('ssh_version_numeric') do
+  setcode do
+    ssh_version = Facter.value(:ssh_version)
+    if ssh_version
+      ssh_version.match(/\d+\.\d+/)[0]
+    end
+  end
+end


### PR DESCRIPTION
Contains two facts, ssh_version and ssh_version_numeric.

Examples:
  ssh_version         = 'OpenSSH_6.2p2'
  ssh_version_numeric = '6.2'