### PR TITLE
Improved control over exported host keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,18 @@ Export node SSH key. Valid values are 'present' and 'absent'.
 
 - *Default*: 'present'
 
+ssh_key_export
+--------------
+Controls whether node SSH host key should be exported. Valid values are 'true and 'false'.
+
+- *Default*: 'true'
+
+ssh_key_host_aliases
+--------------
+Specifies any alias(es) for the node's exported host key. Passed directly to the sshkey exported resource. Valid values are a string or array of strings.
+
+- *Default*: undef
+
 ssh_key_import
 --------------
 Import all exported node SSH keys. Valid values are 'true' and 'false'.
@@ -594,7 +606,7 @@ Import all exported node SSH keys. Valid values are 'true' and 'false'.
 
 ssh_key_type
 ------------
-Encryption type for SSH key. Valid values are 'rsa', 'dsa', 'ssh-dss' and 'ssh-rsa'
+Encryption type for SSH key. Valid values are 'rsa', 'dsa', 'ssh-dss', 'ssh-rsa', 'ssh-ed25519', 'ed25519', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', and 'ecdsa-sha2-nistp521'
 
 - *Default*: 'ssh-rsa'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -595,7 +595,7 @@ class ssh (
       $key = $::sshdsakey
     }
     'ssh-ed25519', 'ed25519': {
-      $key = $::sshed25519key 
+      $key = $::sshed25519key
     }
     'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521': {
       $key = $::sshecdsakey

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3285,6 +3285,63 @@ describe 'ssh' do
       end
     end
   end
+  
+  describe 'with ssh_key_export parameter specified' do
+    context 'as a non-boolean or non-string' do
+    let(:params) { { :ssh_key_export => ['not_a_boolean','or_a_string'] } }
+
+      it 'should fail' do
+        expect {
+          should contain_class('ssh')
+        }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context 'as an invalid string' do
+      let(:params) { { :ssh_key_export => 'invalid_string' } }
+      let(:facts) do
+        { :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '6',
+        }
+      end
+
+      it 'should fail' do
+        expect {
+          should contain_class('ssh')
+        }.to raise_error(Puppet::Error,/ssh::ssh_key_export may be either 'true' or 'false' and is set to <invalid_string>\./)
+      end
+    end
+
+    ['true',true].each do |value|
+      context "as #{value}" do
+        let(:params) { { :ssh_key_export => value } }
+        let(:facts) do
+          { :osfamily          => 'RedHat',
+            :lsbmajdistrelease => '6',
+          }
+        end
+
+        it { should compile.with_all_deps }
+
+        it { should contain_class('ssh') }
+      end
+    end
+
+    ['false',false].each do |value|
+      context "as #{value}" do
+        let(:params) { { :ssh_key_export => value } }
+        let(:facts) do
+          { :osfamily          => 'RedHat',
+            :lsbmajdistrelease => '6',
+          }
+        end
+
+        it { should compile.with_all_deps }
+
+        it { should contain_class('ssh') }
+      end
+    end
+  end
 
   describe 'with parameter sshd_hostbasedauthentication' do
     let(:facts) do


### PR DESCRIPTION
Added a new ssh_key_export parameter to control whether the node exports its SSH host key (mirroring the existing ssh_key_import parameter). Defaults to true for backwards compatibility.

Added a new ssh_key_host_aliases parameter to allow passing host aliases to the exported sshkey declaration (allows setting e.g. hostname and IP address as aliases alongside the FQDN). Defaults to undef for backwards compatibility.

Expanded ssh_key_type parameter checks to support ed25519 and ecdsa keys - all listed type strings are pulled straight from the Puppet Type Reference.
