### PR TITLE
adding sshd_config_ports param to permit multiple listen ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ String to specify listen port for sshd. Port option in sshd_config.
 
 - *Default*: '22'
 
+sshd_config_ports
+---------------------------
+Array to specify optional, additional listen ports for sshd.  Should not include value specified above in sshd_config_port.
+
+- *Default*: undef
+
 sshd_config_syslog_facility
 ---------------------------
 SyslogFacility option in sshd_config.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class ssh (
   $sshd_config_loglevel                = 'INFO',
   $sshd_config_mode                    = 'USE_DEFAULTS',
   $sshd_config_port                    = '22',
+  $sshd_config_ports                   = undef,
   $sshd_config_syslog_facility         = 'AUTH',
   $sshd_config_template                = 'ssh/sshd_config.erb',
   $sshd_config_login_grace_time        = '120',
@@ -431,7 +432,10 @@ class ssh (
   if $ssh_config_hash_known_hosts_real != undef {
     validate_re($ssh_config_hash_known_hosts_real, '^(yes|no)$', "ssh::ssh_config_hash_known_hosts may be either 'yes' or 'no' and is set to <${ssh_config_hash_known_hosts_real}>.")
   }
-  validate_re($sshd_config_port, '^\d+$', "ssh::sshd_config_port must be a valid number and is set to <${sshd_config_port}>.")
+  validate_integer($sshd_config_port)
+  if $sshd_config_ports {
+    validate_array($sshd_config_ports)
+  }
   if $sshd_kerberos_authentication != undef {
     validate_re($sshd_kerberos_authentication, '^(yes|no)$', "ssh::sshd_kerberos_authentication may be either 'yes' or 'no' and is set to <${sshd_kerberos_authentication}>.")
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1127,6 +1127,7 @@ describe 'ssh' do
     let :params do
       {
         :sshd_config_port                  => '22222',
+        :sshd_config_ports                 => [ '22223' ],
         :sshd_config_syslog_facility       => 'DAEMON',
         :sshd_config_login_grace_time      => '60',
         :permit_root_login                 => 'no',
@@ -1198,6 +1199,7 @@ describe 'ssh' do
     }
 
     it { should contain_file('sshd_config').with_content(/^Port 22222$/) }
+    it { should contain_file('sshd_config').with_content(/^Port 22223$/) }
     it { should contain_file('sshd_config').with_content(/^SyslogFacility DAEMON$/) }
     it { should contain_file('sshd_config').with_content(/^LogLevel INFO$/) }
     it { should contain_file('sshd_config').with_content(/^LoginGraceTime 60$/) }
@@ -1815,6 +1817,54 @@ describe 'ssh' do
       expect {
         should contain_class('ssh')
       }.to raise_error(Puppet::Error,/ssh::sshd_config_port must be a valid number and is set to <22invalid>\./)
+    end
+  end
+
+  describe 'sshd_config_ports param' do
+    context 'when set to an array' do
+      let :facts do
+        {
+          :fqdn      => 'monkey.example.com',
+          :osfamily  => 'RedHat',
+          :root_home => '/root',
+          :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='
+        }
+      end
+      let (:params) {{'sshd_config_ports' => ['22222','22223'] }}
+
+      it { should contain_file('sshd_config').with_content(/^Port 22222\nPort 22223$/) }
+    end
+
+    context 'when set to a string' do
+      let :facts do
+        {
+          :fqdn      => 'monkey.example.com',
+          :osfamily  => 'RedHat',
+          :root_home => '/root',
+          :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='
+        }
+      end
+      let (:params) {{'sshd_config_ports' => ['2222'] }}
+
+      it { should contain_file('sshd_config').with_content(/^Port 2222$/) }
+    end
+
+    context 'when set to an invalid type (not an array)' do
+      let :facts do
+        {
+          :fqdn      => 'monkey.example.com',
+          :osfamily  => 'RedHat',
+          :root_home => '/root',
+          :sshrsakey => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArGElx46pD6NNnlxVaTbp0ZJMgBKCmbTCT3RaeCk0ZUJtQ8wkcwTtqIXmmiuFsynUT0DFSd8UIodnBOPqitimmooAVAiAi30TtJVzADfPScMiUnBJKZajIBkEMkwUcqsfh630jyBvLPE/kyQcxbEeGtbu1DG3monkeymanOBW1AKc5o+cJLXcInLnbowMG7NXzujT3BRYn/9s5vtT1V9cuZJs4XLRXQ50NluxJI7sVfRPVvQI9EMbTS4AFBXUej3yfgaLSV+nPZC/lmJ2gR4t/tKvMFF9m16f8IcZKK7o0rK7v81G/tREbOT5YhcKLK+0wBfR6RsmHzwy4EddZloyLQ=='
+        }
+      end
+      let (:params) {{'sshd_config_ports' => true }}
+
+      it 'should fail' do
+        expect {
+          should contain_class('ssh')
+        }.to raise_error(Puppet::Error)
+      end
     end
   end
 

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -15,6 +15,11 @@
 
 #Port 22
 Port <%= @sshd_config_port %>
+<% if @sshd_config_ports.class == Array -%>
+<% @sshd_config_ports.each do |port| -%>
+Port <%= port %>
+<% end -%>
+<% end -%>
 #Protocol 2,1
 Protocol 2
 #AddressFamily any


### PR DESCRIPTION
This PR, inspired by https://github.com/ghoneycutt/puppet-module-ssh/issues/130 , adds a new param **sshd_config_ports** to permit specification of additional ports in sshd_config.  This approach, while less than elegant, allows backward compatibility for those using the existing param **sshd_config_port** .

Also tweaked validation on **sshd_config_port**, as it would fail when passed a Fixnum value, i.e. when supplied via hiera.

P.S. I chose not to try to implement **sshd_config_port** as a polymorphic parameter (i.e. would accept either Fixnum, String, or Array), since that would erode the module's ability to validate its parameter inputs. Indeed, despite the README stating such, the parameter **sshd_listen_address** actually isn't polymorphic; [will only accept an array](https://github.com/ghoneycutt/puppet-module-ssh/blob/master/manifests/init.pp#L394).
