### PR TITLE
Change sshd_config_port to support multiple port numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ String or Array to specify address(es) for which sshd will bind. Corresponds to 
 
 sshd_config_port
 ---------------------------
-String to specify listen port for sshd. Port option in sshd_config.
+String, Integer or Array to specify listen port[s] for sshd. Port option in sshd_config.
 
 - *Default*: '22'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -442,7 +442,22 @@ class ssh (
   if $ssh_config_hash_known_hosts_real != undef {
     validate_re($ssh_config_hash_known_hosts_real, '^(yes|no)$', "ssh::ssh_config_hash_known_hosts may be either 'yes' or 'no' and is set to <${ssh_config_hash_known_hosts_real}>.")
   }
-  validate_re($sshd_config_port, '^\d+$', "ssh::sshd_config_port must be a valid number and is set to <${sshd_config_port}>.")
+  case type3x($sshd_config_port) {
+    'string': {
+      validate_re($sshd_config_port, '^\d+$', "ssh::sshd_config_port must be a valid number and is set to <${sshd_config_port}>.")
+      $sshd_config_port_array = [ str2num($sshd_config_port) ]
+    }
+    'array': {
+      $sshd_config_port_array = $sshd_config_port
+    }
+    'integer': {
+      $sshd_config_port_array = [ $sshd_config_port ]
+    }
+    default: {
+      fail('ssh:sshd_config_port must be a string, an integer or an array. ')
+    }
+  }
+  validate_numeric($sshd_config_port_array, 65535, 1)
   if $sshd_kerberos_authentication != undef {
     validate_re($sshd_kerberos_authentication, '^(yes|no)$', "ssh::sshd_kerberos_authentication may be either 'yes' or 'no' and is set to <${sshd_kerberos_authentication}>.")
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -950,21 +950,40 @@ describe 'ssh' do
     end
   end
 
-  context 'with sshd_config_port not being a valid number' do
+  describe 'sshd_config_port param' do
     let :facts do
       default_facts.merge(
         {
         }
       )
     end
-    let :params do
-      { :sshd_config_port => '22invalid' }
+
+    context 'when set to an array' do
+      let (:params) {{'sshd_config_port' => ['22222', '22223'] }}
+
+      it { should contain_file('sshd_config').with_content(/^Port 22222\nPort 22223$/) }
     end
 
-    it 'should fail' do
-      expect {
-        should contain_class('ssh')
-      }.to raise_error(Puppet::Error,/ssh::sshd_config_port must be a valid number and is set to <22invalid>\./)
+    context 'when set to a string' do
+      let (:params) {{'sshd_config_port' => '22222' }}
+
+      it { should contain_file('sshd_config').with_content(/^Port 22222$/) }
+    end
+
+    context 'when set to an integer' do
+      let (:params) {{'sshd_config_port' => 22222 }}
+
+      it { should contain_file('sshd_config').with_content(/^Port 22222$/) }
+    end
+
+    context 'when not set to a valid number' do
+      let (:params) {{'sshd_config_port' => '22invalid' }}
+
+      it 'should fail' do
+        expect {
+          should contain_class('ssh')
+        }.to raise_error(Puppet::Error,/ssh::sshd_config_port must be a valid number and is set to <22invalid>\./)
+      end
     end
   end
 

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -14,7 +14,9 @@
 # default value.
 
 #Port 22
-Port <%= @sshd_config_port %>
+<% @sshd_config_port_array.each do |p| -%>
+<%= "Port #{p}" %>
+<% end -%>
 #Protocol 2,1
 Protocol 2
 #AddressFamily any


### PR DESCRIPTION
Changed validate_re to validate_array and modified the template accordingly.

Fixes GH-130 in a different way than [PR-158](https://github.com/ghoneycutt/puppet-module-ssh/pull/158)