### PR TITLE
Split per-system variables into params.pp as it best practices for mu…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@ class ssh (
   $ssh_config_hash_known_hosts         = 'USE_DEFAULTS',
   $ssh_config_path                     = '/etc/ssh/ssh_config',
   $ssh_config_owner                    = 'root',
-  $ssh_config_group                    = 'root',
+  $ssh_config_group                    = $ssh::params::default_ssh_config_group,
   $ssh_config_mode                     = '0644',
   $ssh_config_forward_x11              = undef,
   $ssh_config_forward_x11_trusted      = 'USE_DEFAULTS',
@@ -31,7 +31,7 @@ class ssh (
   $ssh_gssapidelegatecredentials       = undef,
   $sshd_config_path                    = '/etc/ssh/sshd_config',
   $sshd_config_owner                   = 'root',
-  $sshd_config_group                   = 'root',
+  $sshd_config_group                   = $ssh::params::default_sshd_config_group,
   $sshd_config_loglevel                = 'INFO',
   $sshd_config_mode                    = 'USE_DEFAULTS',
   $sshd_config_port                    = '22',
@@ -62,7 +62,7 @@ class ssh (
   $sshd_authorized_keys_command_user   = undef,
   $sshd_banner_content                 = undef,
   $sshd_banner_owner                   = 'root',
-  $sshd_banner_group                   = 'root',
+  $sshd_banner_group                   = $ssh::params::default_sshd_banner_group,
   $sshd_banner_mode                    = '0644',
   $sshd_config_xauth_location          = 'USE_DEFAULTS',
   $sshd_config_subsystem_sftp          = 'USE_DEFAULTS',
@@ -97,152 +97,13 @@ class ssh (
   $ssh_config_global_known_hosts_file  = '/etc/ssh/ssh_known_hosts',
   $ssh_config_global_known_hosts_list  = undef,
   $ssh_config_global_known_hosts_owner = 'root',
-  $ssh_config_global_known_hosts_group = 'root',
+  $ssh_config_global_known_hosts_group = $ssh::params::default_ssh_config_global_known_hosts_group,
   $ssh_config_global_known_hosts_mode  = '0644',
   $ssh_config_user_known_hosts_file    = undef,
   $keys                                = undef,
   $manage_root_ssh_config              = false,
   $root_ssh_config_content             = "# This file is being maintained by Puppet.\n# DO NOT EDIT\n",
-) {
-
-  case $::osfamily {
-    'RedHat': {
-      $default_packages                        = ['openssh-server',
-                                                  'openssh-clients']
-      $default_service_name                    = 'sshd'
-      $default_ssh_config_hash_known_hosts     = 'no'
-      $default_ssh_config_forward_x11_trusted  = 'yes'
-      $default_ssh_package_source              = undef
-      $default_ssh_package_adminfile           = undef
-      $default_ssh_sendenv                     = true
-      $default_sshd_config_subsystem_sftp      = '/usr/libexec/openssh/sftp-server'
-      $default_sshd_config_mode                = '0600'
-      $default_sshd_config_use_dns             = 'yes'
-      $default_sshd_config_xauth_location      = '/usr/bin/xauth'
-      $default_sshd_use_pam                    = 'yes'
-      $default_sshd_gssapikeyexchange          = undef
-      $default_sshd_pamauthenticationviakbdint = undef
-      $default_sshd_gssapicleanupcredentials   = 'yes'
-      $default_sshd_acceptenv                  = true
-      $default_service_hasstatus               = true
-      $default_sshd_config_serverkeybits       = '1024'
-      $default_sshd_config_hostkey             = [ '/etc/ssh/ssh_host_rsa_key' ]
-      $default_sshd_addressfamily              = 'any'
-    }
-    'Suse': {
-      $default_packages                        = 'openssh'
-      $default_service_name                    = 'sshd'
-      $default_ssh_config_hash_known_hosts     = 'no'
-      $default_ssh_package_source              = undef
-      $default_ssh_package_adminfile           = undef
-      $default_ssh_sendenv                     = true
-      $default_ssh_config_forward_x11_trusted  = 'yes'
-      $default_sshd_config_mode                = '0600'
-      $default_sshd_config_use_dns             = 'yes'
-      $default_sshd_config_xauth_location      = '/usr/bin/xauth'
-      $default_sshd_use_pam                    = 'yes'
-      $default_sshd_gssapikeyexchange          = undef
-      $default_sshd_pamauthenticationviakbdint = undef
-      $default_sshd_gssapicleanupcredentials   = 'yes'
-      $default_sshd_acceptenv                  = true
-      $default_service_hasstatus               = true
-      $default_sshd_config_serverkeybits       = '1024'
-      $default_sshd_config_hostkey             = [ '/etc/ssh/ssh_host_rsa_key' ]
-      $default_sshd_addressfamily              = 'any'
-      case $::architecture {
-        'x86_64': {
-          if ($::operatingsystem == 'SLES') and ($::operatingsystemrelease =~ /^12\./) {
-            $default_sshd_config_subsystem_sftp = '/usr/lib/ssh/sftp-server'
-          } else {
-            $default_sshd_config_subsystem_sftp = '/usr/lib64/ssh/sftp-server'
-          }
-        }
-        'i386' : {
-          $default_sshd_config_subsystem_sftp = '/usr/lib/ssh/sftp-server'
-      }
-        default: {
-          fail("ssh supports architectures x86_64 and i386 for Suse. Detected architecture is <${::architecture}>.")
-        }
-      }
-    }
-    'Debian': {
-      $default_packages                        = ['openssh-server',
-                                                  'openssh-client']
-      $default_service_name                    = 'ssh'
-      $default_ssh_config_forward_x11_trusted  = 'yes'
-      $default_ssh_config_hash_known_hosts     = 'no'
-      $default_ssh_package_source              = undef
-      $default_ssh_package_adminfile           = undef
-      $default_ssh_sendenv                     = true
-      $default_sshd_config_subsystem_sftp      = '/usr/lib/openssh/sftp-server'
-      $default_sshd_config_mode                = '0600'
-      $default_sshd_config_use_dns             = 'yes'
-      $default_sshd_config_xauth_location      = '/usr/bin/xauth'
-      $default_sshd_use_pam                    = 'yes'
-      $default_sshd_gssapikeyexchange          = undef
-      $default_sshd_pamauthenticationviakbdint = undef
-      $default_sshd_gssapicleanupcredentials   = 'yes'
-      $default_sshd_acceptenv                  = true
-      $default_service_hasstatus               = true
-      $default_sshd_config_serverkeybits       = '1024'
-      $default_sshd_config_hostkey             = [ '/etc/ssh/ssh_host_rsa_key' ]
-      $default_sshd_addressfamily              = 'any'
-    }
-    'Solaris': {
-      $default_ssh_config_hash_known_hosts     = undef
-      $default_ssh_sendenv                     = false
-      $default_ssh_config_forward_x11_trusted  = undef
-      $default_sshd_config_subsystem_sftp      = '/usr/lib/ssh/sftp-server'
-      $default_sshd_config_mode                = '0644'
-      $default_sshd_config_use_dns             = undef
-      $default_sshd_config_xauth_location      = '/usr/openwin/bin/xauth'
-      $default_sshd_use_pam                    = undef
-      $default_sshd_gssapikeyexchange          = 'yes'
-      $default_sshd_pamauthenticationviakbdint = 'yes'
-      $default_sshd_gssapicleanupcredentials   = undef
-      $default_sshd_acceptenv                  = false
-      $default_sshd_config_serverkeybits       = '768'
-      $default_ssh_package_adminfile           = undef
-      $default_sshd_config_hostkey             = [ '/etc/ssh/ssh_host_rsa_key' ]
-      $default_sshd_addressfamily              = undef
-      case $::kernelrelease {
-        '5.11': {
-          $default_packages                      = ['network/ssh',
-                                                    'network/ssh/ssh-key',
-                                                    'service/network/ssh']
-          $default_service_name                  = 'ssh'
-          $default_service_hasstatus             = true
-          $default_ssh_package_source            = undef
-        }
-        '5.10': {
-          $default_packages                      = ['SUNWsshcu',
-                                                    'SUNWsshdr',
-                                                    'SUNWsshdu',
-                                                    'SUNWsshr',
-                                                    'SUNWsshu']
-          $default_service_name                  = 'ssh'
-          $default_service_hasstatus             = true
-          $default_ssh_package_source            = '/var/spool/pkg'
-        }
-        '5.9' : {
-          $default_packages                      = ['SUNWsshcu',
-                                                    'SUNWsshdr',
-                                                    'SUNWsshdu',
-                                                    'SUNWsshr',
-                                                    'SUNWsshu']
-          $default_service_name                  = 'sshd'
-          $default_service_hasstatus             = false
-          $default_ssh_package_source            = '/var/spool/pkg'
-        }
-        default: {
-          fail('ssh module supports Solaris kernel release 5.9, 5.10 and 5.11.')
-        }
-      }
-    }
-    default: {
-      fail("ssh supports osfamilies RedHat, Suse, Debian and Solaris. Detected osfamily is <${::osfamily}>.")
-    }
-  }
+) inherits ssh::params {
 
   if "${::ssh_version}" =~ /^OpenSSH/  { # lint:ignore:only_variable_string
     $ssh_version_array = split($::ssh_version_numeric, '\.')
@@ -742,10 +603,12 @@ class ssh (
     validate_array($sshd_config_allowgroups_real)
   }
 
-  package { $packages_real:
-    ensure    => installed,
-    source    => $ssh_package_source_real,
-    adminfile => $ssh_package_adminfile_real,
+  if $packages_real != undef {
+    package { $packages_real:
+      ensure    => installed,
+      source    => $ssh_package_source_real,
+      adminfile => $ssh_package_adminfile_real,
+    }
   }
 
   file  { 'ssh_config' :
@@ -790,7 +653,7 @@ class ssh (
       ensure  => directory,
       path    => "${::root_home}/.ssh",
       owner   => 'root',
-      group   => 'root',
+      group   => $ssh_config_group,
       mode    => '0700',
       require => Common::Mkdir_p["${::root_home}/.ssh"],
     }
@@ -800,7 +663,7 @@ class ssh (
       path    => "${::root_home}/.ssh/config",
       content => $root_ssh_config_content,
       owner   => 'root',
-      group   => 'root',
+      group   => $ssh_config_group,
       mode    => '0600',
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,185 @@
+# == Class: ssh::params
+#
+class ssh::params {
+
+  case $::osfamily {
+    'FreeBSD': {
+      $default_packages                            = undef
+      $default_service_name                        = 'sshd'
+      $default_ssh_config_forward_x11_trusted      = 'yes'
+      $default_ssh_config_global_known_hosts_group = 'wheel'
+      $default_ssh_config_group                    = 'wheel'
+      $default_ssh_config_hash_known_hosts         = 'no'
+      $default_ssh_package_source                  = undef
+      $default_ssh_package_adminfile               = undef
+      $default_ssh_sendenv                         = true
+      $default_sshd_banner_group                   = 'wheel'
+      $default_sshd_config_group                   = 'wheel'
+      $default_sshd_config_subsystem_sftp          = '/usr/libexec/sftp-server'
+      $default_sshd_config_mode                    = '0644'
+      $default_sshd_config_use_dns                 = 'yes'
+      $default_sshd_config_xauth_location          = '/usr/local/bin/xauth'
+      $default_sshd_use_pam                        = 'yes'
+      $default_sshd_gssapikeyexchange              = undef
+      $default_sshd_pamauthenticationviakbdint     = undef
+      $default_sshd_gssapicleanupcredentials       = 'yes'
+      $default_sshd_acceptenv                      = true
+      $default_service_hasstatus                   = true
+      $default_sshd_config_serverkeybits           = '1024'
+      $default_sshd_config_hostkey                 = [ '/etc/ssh/ssh_host_rsa_key' ]
+      $default_sshd_addressfamily                  = 'any'
+    }
+    'RedHat': {
+      $default_packages                            = ['openssh-server',
+                                                       'openssh-clients']
+      $default_service_name                        = 'sshd'
+      $default_ssh_config_hash_known_hosts         = 'no'
+      $default_ssh_config_forward_x11_trusted      = 'yes'
+      $default_ssh_config_global_known_hosts_group = 'root'
+      $default_ssh_config_group                    = 'root'
+      $default_ssh_package_source                  = undef
+      $default_ssh_package_adminfile               = undef
+      $default_ssh_sendenv                         = true
+      $default_sshd_banner_group                   = 'root'
+      $default_sshd_config_group                   = 'root'
+      $default_sshd_config_subsystem_sftp          = '/usr/libexec/openssh/sftp-server'
+      $default_sshd_config_mode                    = '0600'
+      $default_sshd_config_use_dns                 = 'yes'
+      $default_sshd_config_xauth_location          = '/usr/bin/xauth'
+      $default_sshd_use_pam                        = 'yes'
+      $default_sshd_gssapikeyexchange              = undef
+      $default_sshd_pamauthenticationviakbdint     = undef
+      $default_sshd_gssapicleanupcredentials       = 'yes'
+      $default_sshd_acceptenv                      = true
+      $default_service_hasstatus                   = true
+      $default_sshd_config_serverkeybits           = '1024'
+      $default_sshd_config_hostkey                 = [ '/etc/ssh/ssh_host_rsa_key' ]
+      $default_sshd_addressfamily                  = 'any'
+    }
+    'Suse': {
+      $default_packages                            = 'openssh'
+      $default_service_name                        = 'sshd'
+      $default_ssh_config_hash_known_hosts         = 'no'
+      $default_ssh_package_source                  = undef
+      $default_ssh_package_adminfile               = undef
+      $default_ssh_sendenv                         = true
+      $default_sshd_config_group                   = 'root'
+      $default_ssh_config_forward_x11_trusted      = 'yes'
+      $default_ssh_config_global_known_hosts_group = 'root'
+      $default_ssh_config_group                    = 'root'
+      $default_sshd_banner_group                   = 'root'
+      $default_sshd_config_mode                    = '0600'
+      $default_sshd_config_use_dns                 = 'yes'
+      $default_sshd_config_xauth_location          = '/usr/bin/xauth'
+      $default_sshd_use_pam                        = 'yes'
+      $default_sshd_gssapikeyexchange              = undef
+      $default_sshd_pamauthenticationviakbdint     = undef
+      $default_sshd_gssapicleanupcredentials       = 'yes'
+      $default_sshd_acceptenv                      = true
+      $default_service_hasstatus                   = true
+      $default_sshd_config_serverkeybits           = '1024'
+      $default_sshd_config_hostkey                 = [ '/etc/ssh/ssh_host_rsa_key' ]
+      $default_sshd_addressfamily                  = 'any'
+      case $::architecture {
+        'x86_64': {
+          if ($::operatingsystem == 'SLES') and ($::operatingsystemrelease =~ /^12\./) {
+            $default_sshd_config_subsystem_sftp = '/usr/lib/ssh/sftp-server'
+          } else {
+            $default_sshd_config_subsystem_sftp = '/usr/lib64/ssh/sftp-server'
+          }
+        }
+        'i386' : {
+          $default_sshd_config_subsystem_sftp = '/usr/lib/ssh/sftp-server'
+      }
+        default: {
+          fail("ssh supports architectures x86_64 and i386 for Suse. Detected architecture is <${::architecture}>.")
+        }
+      }
+    }
+    'Debian': {
+      $default_packages                            = ['openssh-server',
+                                                        'openssh-client']
+      $default_service_name                        = 'ssh'
+      $default_ssh_config_forward_x11_trusted      = 'yes'
+      $default_ssh_config_global_known_hosts_group = 'root'
+      $default_ssh_config_group                    = 'root'
+      $default_ssh_config_hash_known_hosts         = 'no'
+      $default_ssh_package_source                  = undef
+      $default_ssh_package_adminfile               = undef
+      $default_ssh_sendenv                         = true
+      $default_sshd_banner_group                   = 'root'
+      $default_sshd_config_group                   = 'root'
+      $default_sshd_config_subsystem_sftp          = '/usr/lib/openssh/sftp-server'
+      $default_sshd_config_mode                    = '0600'
+      $default_sshd_config_use_dns                 = 'yes'
+      $default_sshd_config_xauth_location          = '/usr/bin/xauth'
+      $default_sshd_use_pam                        = 'yes'
+      $default_sshd_gssapikeyexchange              = undef
+      $default_sshd_pamauthenticationviakbdint     = undef
+      $default_sshd_gssapicleanupcredentials       = 'yes'
+      $default_sshd_acceptenv                      = true
+      $default_service_hasstatus                   = true
+      $default_sshd_config_serverkeybits           = '1024'
+      $default_sshd_config_hostkey                 = [ '/etc/ssh/ssh_host_rsa_key' ]
+      $default_sshd_addressfamily                  = 'any'
+    }
+    'Solaris': {
+      $default_ssh_config_hash_known_hosts         = undef
+      $default_ssh_sendenv                         = false
+      $default_ssh_config_forward_x11_trusted      = undef
+      $default_ssh_config_global_known_hosts_group = 'root'
+      $default_ssh_config_group                    = 'root'
+      $default_sshd_banner_group                   = 'root'
+      $default_sshd_config_group                   = 'root'
+      $default_sshd_config_subsystem_sftp          = '/usr/lib/ssh/sftp-server'
+      $default_sshd_config_mode                    = '0644'
+      $default_sshd_config_use_dns                 = undef
+      $default_sshd_config_xauth_location          = '/usr/openwin/bin/xauth'
+      $default_sshd_use_pam                        = undef
+      $default_sshd_gssapikeyexchange              = 'yes'
+      $default_sshd_pamauthenticationviakbdint     = 'yes'
+      $default_sshd_gssapicleanupcredentials       = undef
+      $default_sshd_acceptenv                      = false
+      $default_sshd_config_serverkeybits           = '768'
+      $default_ssh_package_adminfile               = undef
+      $default_sshd_config_hostkey                 = [ '/etc/ssh/ssh_host_rsa_key' ]
+      $default_sshd_addressfamily                  = undef
+      case $::kernelrelease {
+        '5.11': {
+          $default_packages                          = ['network/ssh',
+                                                        'network/ssh/ssh-key',
+                                                        'service/network/ssh']
+          $default_service_name                      = 'ssh'
+          $default_service_hasstatus                 = true
+          $default_ssh_package_source                = undef
+        }
+        '5.10': {
+          $default_packages                          = ['SUNWsshcu',
+                                                        'SUNWsshdr',
+                                                        'SUNWsshdu',
+                                                        'SUNWsshr',
+                                                        'SUNWsshu']
+          $default_service_name                      = 'ssh'
+          $default_service_hasstatus                 = true
+          $default_ssh_package_source                = '/var/spool/pkg'
+        }
+        '5.9' : {
+          $default_packages                          = ['SUNWsshcu',
+                                                        'SUNWsshdr',
+                                                        'SUNWsshdu',
+                                                        'SUNWsshr',
+                                                        'SUNWsshu']
+          $default_service_name                      = 'sshd'
+          $default_service_hasstatus                 = false
+          $default_ssh_package_source                = '/var/spool/pkg'
+        }
+        default: {
+          fail('ssh module supports Solaris kernel release 5.9, 5.10 and 5.11.')
+        }
+      }
+    }
+    default: {
+      fail("ssh supports osfamilies RedHat, Suse, Debian, Solaris and FreeBSD. Detected osfamily is <${::osfamily}>.")
+    }
+  }
+}


### PR DESCRIPTION
…lti-OS modules (Cleanup for root group: some places was hardcoded on 'root' value instead of ssh_config_group variables. Add FreeBSD platform support: tested on FreeBSD 10.x and FreeBSD 11