### PR TITLE
Expose TCPKeepAlive from sshd_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,19 @@ after approximately 45 seconds.  This option applies to protocol version 2 only.
 
 - *Default*: '3'
 
+sshd_config_tcp_keepalive
+------------------------
+TCPKeepAlive in sshd_config.
+Specifies  whether the system should send TCP keepalive messages to the other side.  If they
+are sent, death of the connection or crash of one of the machines will be properly noticed.
+However, this means that connections will die if the route is down temporarily, and some
+people find it annoying.  On the other hand, if TCP keepalives are not sent, sessions may
+hang indefinitely on the server, leaving ``ghost'' users and consuming server resources.
+The default is ``yes'' (to send TCP keepalive messages), and the server will notice if the
+network goes down or the client host crashes.  This avoids infinitely hanging sessions.
+
+- *Default*: 'yes'
+
 sshd_config_ciphers
 -------------------
 Array of ciphers for the Ciphers setting in sshd_config.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,6 +105,7 @@ class ssh (
   $keys                                = undef,
   $manage_root_ssh_config              = false,
   $root_ssh_config_content             = "# This file is being maintained by Puppet.\n# DO NOT EDIT\n",
+  $sshd_config_tcp_keepalive           = 'yes',
 ) {
 
   case $::osfamily {
@@ -750,6 +751,7 @@ class ssh (
     validate_array($sshd_config_allowgroups_real)
   }
 
+  validate_re($sshd_config_tcp_keepalive, '^(yes|no)$', "ssh::sshd_config_tcp_keepalive may be either 'yes' or 'no' and is set to <${sshd_config_tcp_keepalive}>.")
   package { $packages_real:
     ensure    => installed,
     source    => $ssh_package_source_real,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -438,6 +438,7 @@ describe 'ssh' do
         :sshd_listen_address               => [ '192.168.1.1',
                                                 '2001:db8::dead:f00d',
         ],
+        :sshd_config_tcp_keepalive         => 'yes',
       }
     end
 
@@ -503,6 +504,7 @@ describe 'ssh' do
     it { should contain_file('sshd_config').with_content(/^\s*AllowUsers foo bar$/) }
     it { should contain_file('sshd_config').with_content(/^\s*AllowGroups ssh security$/) }
     it { should contain_file('sshd_config').with_content(/^ListenAddress 192.168.1.1\nListenAddress 2001:db8::dead:f00d$/) }
+    it { should contain_file('sshd_config').with_content(/^TCPKeepAlive yes$/) }
 
     it {
       should contain_file('sshd_banner').with({
@@ -2756,6 +2758,25 @@ describe 'ssh' do
       context "specified as valid false value #{value} (as #{value.class})" do
         let(:params) { { :manage_service => value } }
         it { should_not contain_service('sshd_service') }
+      end
+    end
+  end
+
+  describe 'sshd_config_tcp_keepalive param' do
+    let :facts do
+      default_facts.merge(
+        {
+        }
+      )
+    end
+
+    context 'when set to invalid' do
+      let (:params) { { :sshd_config_tcp_keepalive => 'invalid' } }
+
+      it 'should fail' do
+        expect {
+          should contain_class('ssh')
+        }.to raise_error(Puppet::Error,/ssh::sshd_config_tcp_keepalive may be either \'yes\' or \'no\' and is set to <invalid>\./)
       end
     end
   end

--- a/spec/fixtures/sshd_config_debian
+++ b/spec/fixtures/sshd_config_debian
@@ -111,6 +111,7 @@ X11Forwarding yes
 PrintMotd yes
 #PrintLastLog yes
 #TCPKeepAlive yes
+TCPKeepAlive yes
 #UseLogin no
 #UsePrivilegeSeparation yes
 #PermitUserEnvironment no

--- a/spec/fixtures/sshd_config_rhel
+++ b/spec/fixtures/sshd_config_rhel
@@ -111,6 +111,7 @@ X11Forwarding yes
 PrintMotd yes
 #PrintLastLog yes
 #TCPKeepAlive yes
+TCPKeepAlive yes
 #UseLogin no
 #UsePrivilegeSeparation yes
 #PermitUserEnvironment no

--- a/spec/fixtures/sshd_config_sles_12_x86_64
+++ b/spec/fixtures/sshd_config_sles_12_x86_64
@@ -111,6 +111,7 @@ X11Forwarding yes
 PrintMotd yes
 #PrintLastLog yes
 #TCPKeepAlive yes
+TCPKeepAlive yes
 #UseLogin no
 #UsePrivilegeSeparation yes
 #PermitUserEnvironment no

--- a/spec/fixtures/sshd_config_solaris
+++ b/spec/fixtures/sshd_config_solaris
@@ -100,6 +100,7 @@ X11Forwarding yes
 PrintMotd yes
 #PrintLastLog yes
 #TCPKeepAlive yes
+TCPKeepAlive yes
 #UseLogin no
 #UsePrivilegeSeparation yes
 #PermitUserEnvironment no

--- a/spec/fixtures/sshd_config_suse_i386
+++ b/spec/fixtures/sshd_config_suse_i386
@@ -111,6 +111,7 @@ X11Forwarding yes
 PrintMotd yes
 #PrintLastLog yes
 #TCPKeepAlive yes
+TCPKeepAlive yes
 #UseLogin no
 #UsePrivilegeSeparation yes
 #PermitUserEnvironment no

--- a/spec/fixtures/sshd_config_suse_x86_64
+++ b/spec/fixtures/sshd_config_suse_x86_64
@@ -111,6 +111,7 @@ X11Forwarding yes
 PrintMotd yes
 #PrintLastLog yes
 #TCPKeepAlive yes
+TCPKeepAlive yes
 #UseLogin no
 #UsePrivilegeSeparation yes
 #PermitUserEnvironment no

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -165,6 +165,7 @@ X11Forwarding <%= @sshd_x11_forwarding %>
 PrintMotd <%= @sshd_config_print_motd %>
 #PrintLastLog yes
 #TCPKeepAlive yes
+TCPKeepAlive <%= @sshd_config_tcp_keepalive %>
 #UseLogin no
 #UsePrivilegeSeparation yes
 #PermitUserEnvironment no


### PR DESCRIPTION
This will expose TCPKeepAlive parameter from sshd_config via ssh::sshd_config_tcp_keepalive. Defaults to 'yes'.