### PR TITLE
Expose PermitTunnel from sshd_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,18 @@ network goes down or the client host crashes.  This avoids infinitely hanging se
 
 - *Default*: 'yes'
 
+sshd_config_permittunnel
+-----------------------
+PermitTunnel in sshd_config.
+Specifies whether tun(4) device forwarding is allowed.  The argument must be
+'yes', 'point-to-point' (layer 3), 'ethernet' (layer 2), or 'no'.
+Specifying 'yes' permits both 'point-to-point' and 'ethernet'.  The
+default is 'no'.
+Independent of this setting, the permissions of the selected tun(4) device must
+allow access to the user.
+
+- *Default*: 'no'
+
 sshd_config_ciphers
 -------------------
 Array of ciphers for the Ciphers setting in sshd_config.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,7 @@ class ssh (
   $manage_root_ssh_config              = false,
   $root_ssh_config_content             = "# This file is being maintained by Puppet.\n# DO NOT EDIT\n",
   $sshd_config_tcp_keepalive           = 'yes',
+  $sshd_config_permittunnel            = 'no',
 ) {
 
   case $::osfamily {
@@ -764,6 +765,9 @@ class ssh (
   }
 
   validate_re($sshd_config_tcp_keepalive, '^(yes|no)$', "ssh::sshd_config_tcp_keepalive may be either 'yes' or 'no' and is set to <${sshd_config_tcp_keepalive}>.")
+
+  validate_re($sshd_config_permittunnel, '^(yes|no|point-to-point|ethernet)$', "ssh::sshd_config_permittunnel may be either 'yes', 'point-to-point', 'ethernet' or 'no' and is set to <${sshd_config_permittunnel}>.")
+
   package { $packages_real:
     ensure    => installed,
     source    => $ssh_package_source_real,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -430,6 +430,7 @@ describe 'ssh' do
                                                 '2001:db8::dead:f00d',
         ],
         :sshd_config_tcp_keepalive         => 'yes',
+        :sshd_config_permittunnel          => 'no',
       }
     end
 
@@ -496,6 +497,7 @@ describe 'ssh' do
     it { should contain_file('sshd_config').with_content(/^\s*AllowGroups ssh security$/) }
     it { should contain_file('sshd_config').with_content(/^ListenAddress 192.168.1.1\nListenAddress 2001:db8::dead:f00d$/) }
     it { should contain_file('sshd_config').with_content(/^TCPKeepAlive yes$/) }
+    it { should contain_file('sshd_config').with_content(/^PermitTunnel no$/) }
 
     it {
       should contain_file('sshd_banner').with({
@@ -904,6 +906,26 @@ describe 'ssh' do
         expect {
           should contain_class('ssh')
         }.to raise_error(Puppet::Error,/ssh::sshd_config_port must be a valid number and is set to <22invalid>\./)
+      end
+    end
+  end
+
+  describe 'sshd_config_permittunnel param' do
+    ['yes','point-to-point','ethernet','no'].each do |value|
+      context "set to #{value}" do
+        let (:params) { { :sshd_config_permittunnel => value } }
+
+        it { should contain_file('sshd_config').with_content(/^PermitTunnel #{value}$/) }
+      end
+    end
+
+    context 'when set to an invalid value' do
+      let (:params) { { :sshd_config_permittunnel => 'invalid' } }
+
+      it 'should fail' do
+        expect {
+          should contain_class('ssh')
+        }.to raise_error(Puppet::Error,/ssh::sshd_config_permittunnel may be either \'yes\', \'point-to-point\', \'ethernet\' or \'no\' and is set to <invalid>\./)
       end
     end
   end

--- a/spec/fixtures/sshd_config_debian
+++ b/spec/fixtures/sshd_config_debian
@@ -127,6 +127,7 @@ UseDNS yes
 #MaxSessions 10
 
 #PermitTunnel no
+PermitTunnel no
 #ChrootDirectory none
 
 # no default banner path

--- a/spec/fixtures/sshd_config_rhel
+++ b/spec/fixtures/sshd_config_rhel
@@ -127,6 +127,7 @@ UseDNS yes
 #MaxSessions 10
 
 #PermitTunnel no
+PermitTunnel no
 #ChrootDirectory none
 
 # no default banner path

--- a/spec/fixtures/sshd_config_sles_12_x86_64
+++ b/spec/fixtures/sshd_config_sles_12_x86_64
@@ -127,6 +127,7 @@ UseDNS yes
 #MaxSessions 10
 
 #PermitTunnel no
+PermitTunnel no
 #ChrootDirectory none
 
 # no default banner path

--- a/spec/fixtures/sshd_config_solaris
+++ b/spec/fixtures/sshd_config_solaris
@@ -114,6 +114,7 @@ ClientAliveCountMax 3
 #MaxSessions 10
 
 #PermitTunnel no
+PermitTunnel no
 #ChrootDirectory none
 
 # no default banner path

--- a/spec/fixtures/sshd_config_suse_i386
+++ b/spec/fixtures/sshd_config_suse_i386
@@ -127,6 +127,7 @@ UseDNS yes
 #MaxSessions 10
 
 #PermitTunnel no
+PermitTunnel no
 #ChrootDirectory none
 
 # no default banner path

--- a/spec/fixtures/sshd_config_suse_x86_64
+++ b/spec/fixtures/sshd_config_suse_x86_64
@@ -127,6 +127,7 @@ UseDNS yes
 #MaxSessions 10
 
 #PermitTunnel no
+PermitTunnel no
 #ChrootDirectory none
 
 # no default banner path

--- a/spec/fixtures/sshd_config_ubuntu1604
+++ b/spec/fixtures/sshd_config_ubuntu1604
@@ -130,6 +130,7 @@ UseDNS yes
 #MaxSessions 10
 
 #PermitTunnel no
+PermitTunnel no
 #ChrootDirectory none
 
 # no default banner path

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -194,6 +194,7 @@ MaxSessions <%= @sshd_config_maxsessions %>
 <% end -%>
 
 #PermitTunnel no
+PermitTunnel <%= @sshd_config_permittunnel %>
 <% if @sshd_config_chrootdirectory -%>
 ChrootDirectory <%= @sshd_config_chrootdirectory %>
 <% else -%>


### PR DESCRIPTION
This will expose PermitTunnel from sshd_config via ssh:sshd_config_permittunnel. Defaults to no.