### PR TITLE
Add option and parameter for TrustedUserCAKeys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,14 @@ String of user for AuthorizedKeysCommandUser in sshd_config.
 
 - *Default*: undef
 
+sshd_config_trusted_user_ca_keys
+--------------------------------
+Fully qualified path to the file containing public keys of certificate
+authorities that are trusted to sign user certificates for authentication.
+This parameter corresponds with the TrustedUserCAKeys setting in sshd_config.
+
+- *Default*: undef
+
 sshd_x11_forwarding
 -------------------
 X11Forwarding in sshd_config. Specifies whether X11 forwarding is permitted.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,7 @@ class ssh (
   $sshd_config_match                   = undef,
   $sshd_authorized_keys_command        = undef,
   $sshd_authorized_keys_command_user   = undef,
+  $sshd_config_trusted_user_ca_keys    = undef,
   $sshd_banner_content                 = undef,
   $sshd_banner_owner                   = 'root',
   $sshd_banner_group                   = 'root',

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -82,6 +82,12 @@ AuthorizedKeysCommand <%= @sshd_authorized_keys_command %>
 AuthorizedKeysCommandUser <%= @sshd_authorized_keys_command_user %>
 <% end -%>
 
+<% if @sshd_config_trusted_user_ca_keys -%>
+# File containing public keys of certificate authorities that are
+# trusted to sign user certificates for authentication.
+TrustedUserCAKeys <%= @sshd_config_trusted_user_ca_keys %>
+
+<% end -%>
 # For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
 #RhostsRSAAuthentication no
 # similar for protocol version 2


### PR DESCRIPTION
This commit adds the `TrustedUserCAKeys` option to the sshd_config
file as well as a corresponding parameter to the public class.
