### PR TITLE
Remove join from validate_absolute_path for sshd_config_hostkey

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -428,7 +428,7 @@ class ssh (
     $sshd_config_hostkey_real = $default_sshd_config_hostkey
   } else {
     validate_array($sshd_config_hostkey)
-    validate_absolute_path(join($sshd_config_hostkey))
+    validate_absolute_path($sshd_config_hostkey)
     $sshd_config_hostkey_real = $sshd_config_hostkey
   }
 


### PR DESCRIPTION
The validate_absolute_path function is able to parse arrays already. The join results into a invalid absolute path. 