### PR TITLE
define permittunnel to prevent getting locked out

### DIFF
--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -194,8 +194,11 @@ MaxSessions <%= @sshd_config_maxsessions %>
 #MaxSessions 10
 <% end -%>
 
-#PermitTunnel no
+<% if @sshd_config_permittunnel -%>
 PermitTunnel <%= @sshd_config_permittunnel %>
+<% else -%>
+PermitTunnel no
+<% end -%>
 <% if @sshd_config_chrootdirectory -%>
 ChrootDirectory <%= @sshd_config_chrootdirectory %>
 <% else -%>


### PR DESCRIPTION
If ssh::sshd_config_permittunnel is not defined, no value gets printed after PermitTunnel, locking you of of an SSH server (just experienced it on a couple of machines at home... :s ). Fixed it with an if loop and default value if not defined.