### PR TITLE
Option to not manage global_known_hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ X11Forwarding in sshd_config. Specifies whether X11 forwarding is permitted.
 
 sshd_x11_use_localhost
 ----------------------
-X11UseLocalhost in sshd_config. Specifies if sshd should bind the X11 forwarding server 
+X11UseLocalhost in sshd_config. Specifies if sshd should bind the X11 forwarding server
 to the loopback address or to the wildcard address.
 
 - *Default*: 'yes'
@@ -773,6 +773,12 @@ Content of root's ~/.ssh/config.
 manage_service
 --------------
 Manage the sshd service through this module or not.  Valid values are 'true' and 'false'.
+
+- *Default*: 'true'
+
+manage_global_known_hosts
+----------------------
+Manage the global known_hosts file. Valid values are 'true' and 'false'.
 
 - *Default*: 'true'
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1018,6 +1018,16 @@ describe 'ssh' do
     end
   end
 
+  context 'with manage_global_known_hosts set to invalid value on valid osfamily' do
+    let(:params) { { :manage_global_known_hosts => 'invalid' } }
+
+    it 'should fail' do
+      expect {
+        should contain_class('ssh')
+      }.to raise_error(Puppet::Error,/Unknown type of boolean/)
+    end
+  end
+
   context 'with sshd_password_authentication set to invalid value on valid osfamily' do
     let(:params) { { :sshd_password_authentication => 'invalid' } }
 
@@ -1958,6 +1968,43 @@ describe 'ssh' do
         expect {
           should contain_class('ssh')
         }.to raise_error(Puppet::Error,/is not an absolute path/)
+      end
+    end
+  end
+
+  describe 'with parameter manage_global_known_hosts' do
+    ['YES','badvalue',2.42,['array'],a = { 'ha' => 'sh' }].each do |value|
+      context "specified as invalid value #{value} (as #{value.class})" do
+        let(:params) { { :manage_global_known_hosts => value } }
+        it do
+          expect {
+            should contain_class('ssh')
+          }.to raise_error(Puppet::Error,/(is not a boolean|Unknown type of boolean)/)
+        end
+      end
+    end
+
+    ['true', true].each do |value|
+      context "specified as valid true value #{value} (as #{value.class})" do
+        let(:params) { { :manage_global_known_hosts => value } }
+
+        it {
+          should contain_file('ssh_known_hosts').with({
+            'ensure' => 'file',
+            'path'   => '/etc/ssh/ssh_known_hosts',
+            'owner'  => 'root',
+            'group'  => 'root',
+            'mode'   => '0644',
+          })
+        }
+      end
+    end
+
+    ['false', false].each do |value|
+      context "specified as valid false value #{value} (as #{value.class})" do
+        let(:params) { { :manage_global_known_hosts => value } }
+
+        it { should_not contain_file('/etc/ssh/ssh_known_hosts') }
       end
     end
   end


### PR DESCRIPTION
I have here currently a special setup, in which I need to manage the global_known_hosts_file (/etc/ssh/ssh_known_hosts) with an other puppet module.
But I still want use this great module, but I do not see an option available here to ignore that file. Because of that I got a conflict.

Did I have overlooked an option for that?
If there is no option available for that I see currently to possible ways to achive that:
1. If ssh_key_import and purge_keys are the to false, simply ignore the file (I found no other code part that puts content into that file)
2. Create a new option manage_global_known_hosts_file

What do you think about that? If you tell me your prefered way, I can create a PR for that if you want.