### PR TITLE
Add support for 'AuthenticationMethods'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,7 @@ class ssh (
   $sshd_config_ciphers                 = undef,
   $sshd_config_kexalgorithms           = undef,
   $sshd_config_macs                    = undef,
+  $sshd_config_authenticationmethods   = [],
   $ssh_enable_ssh_keysign              = undef,
   $sshd_config_allowgroups             = [],
   $sshd_config_allowusers              = [],

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -196,6 +196,10 @@ MaxSessions <%= @sshd_config_maxsessions_integer %>
 #MaxSessions 10
 <% end -%>
 
+<% if @sshd_config_authenticationmethods != [] -%>
+AuthenticationMethods  <%= @sshd_config_authenticationmethods.join(' ') -%>
+<% end -%>
+
 #PermitTunnel no
 <% if @sshd_config_permittunnel_real != nil -%>
 PermitTunnel <%= @sshd_config_permittunnel_real %>


### PR DESCRIPTION
I use this option to require both password and public key authentication on CentOS 7. This option does not work for the version of OpenSSH packaged for CentOS 6.