### PR TITLE
Add support for sourcing the SSHD banner file

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,13 @@ Banner option in sshd_config.
 
 sshd_banner_content
 -------------------
-content parameter for file specified in sshd_config_banner
+content parameter for file specified in sshd_config_banner. Mutually exclusive with sshd_banner_source
+
+- *Default*: undef
+
+sshd_banner_source
+------------------
+source parameter for file specified in sshd_config_banner. Mutually exclusive with sshd_banner_content
 
 - *Default*: undef
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,7 @@ class ssh (
   $sshd_authorized_keys_command        = undef,
   $sshd_authorized_keys_command_user   = undef,
   $sshd_banner_content                 = undef,
+  $sshd_banner_source                  = undef,
   $sshd_banner_owner                   = 'root',
   $sshd_banner_group                   = 'root',
   $sshd_banner_mode                    = '0644',
@@ -559,6 +560,12 @@ class ssh (
   if $sshd_banner_content != undef and $sshd_config_banner == 'none' {
     fail('ssh::sshd_config_banner must be set to be able to use sshd_banner_content.')
   }
+  if $sshd_banner_source != undef and $sshd_config_banner == 'none' {
+    fail('ssh::sshd_config_banner must be set to be able to use sshd_banner_source.')
+  }
+  if $sshd_banner_content != undef and $sshd_banner_source != undef {
+    fail('ssh::sshd_banner_content is mutually exclusive with ssh::sshd_banner_source')
+  }
 
   validate_re($ssh_gssapiauthentication, '^(yes|no)$', "ssh::ssh_gssapiauthentication may be either 'yes' or 'no' and is set to <${ssh_gssapiauthentication}>.")
 
@@ -834,7 +841,7 @@ class ssh (
     require => Package[$packages_real],
   }
 
-  if $sshd_config_banner != 'none' and $sshd_banner_content != undef {
+  if $sshd_config_banner != 'none' and ( $sshd_banner_content != undef or $sshd_banner_source != undef ) {
     file { 'sshd_banner' :
       ensure  => file,
       path    => $sshd_config_banner,
@@ -842,6 +849,7 @@ class ssh (
       group   => $sshd_banner_group,
       mode    => $sshd_banner_mode,
       content => $sshd_banner_content,
+      source  => $sshd_banner_source,
       require => Package[$packages_real],
     }
   }


### PR DESCRIPTION
I wanted the ability to be able to source the banner file from a puppet:/// URL rather than have the contents in Hiera.

This PR seems to do the trick.