### PR TITLE
Added possibility to add AcceptEnv/SendEnv custom strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ Boolean to enable SendEnv options for specifying environment variables. Default 
 
 - *Default*: 'USE_DEFAULTS'
 
+ssh_sendenv_string
+-------------
+String for SendEnv option for specifying custom environment variables.
+
+- *Default*: undef
+
 ssh_gssapiauthentication
 -------------------------
 GSSAPIAuthentication: Enables/disables GSS-API user authentication in ssh_config. Valid values are 'yes' and 'no'.
@@ -419,7 +425,7 @@ X11Forwarding in sshd_config. Specifies whether X11 forwarding is permitted.
 
 sshd_x11_use_localhost
 ----------------------
-X11UseLocalhost in sshd_config. Specifies if sshd should bind the X11 forwarding server 
+X11UseLocalhost in sshd_config. Specifies if sshd should bind the X11 forwarding server
 to the loopback address or to the wildcard address.
 
 - *Default*: 'yes'
@@ -672,6 +678,12 @@ sshd_acceptenv
 Boolean to enable AcceptEnv options for specifying environment variables. Default is set to true on Linux.
 
 - *Default*: 'USE_DEFAULTS'
+
+sshd_acceptenv_string
+-------------
+String for AcceptEnv option for specifying custom environment variables.
+
+- *Default*: undef
 
 sshd_hostbasedauthentication
 -------------------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -429,8 +429,8 @@ class ssh (
   if $sshd_acceptenv == 'USE_DEFAULTS' {
     $sshd_acceptenv_real = $default_sshd_acceptenv
   } else {
-    if $ssh_acceptenv_string {
-      validate_string($ssh_acceptenv_string)
+    if $sshd_acceptenv_string {
+      validate_string($sshd_acceptenv_string)
     }
     case type3x($sshd_acceptenv) {
       'string': {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,7 @@ class ssh (
   $ssh_config_use_roaming               = 'USE_DEFAULTS',
   $ssh_config_template                  = 'ssh/ssh_config.erb',
   $ssh_sendenv                          = 'USE_DEFAULTS',
+  $ssh_sendenv_string                   = undef,
   $ssh_gssapiauthentication             = 'yes',
   $ssh_gssapidelegatecredentials        = undef,
   $sshd_config_path                     = '/etc/ssh/sshd_config',
@@ -86,6 +87,7 @@ class ssh (
   $sshd_pamauthenticationviakbdint      = 'USE_DEFAULTS',
   $sshd_gssapicleanupcredentials        = 'USE_DEFAULTS',
   $sshd_acceptenv                       = 'USE_DEFAULTS',
+  $sshd_acceptenv_string                = undef,
   $sshd_config_hostkey                  = 'USE_DEFAULTS',
   $sshd_listen_address                  = undef,
   $sshd_hostbasedauthentication         = 'no',
@@ -407,6 +409,9 @@ class ssh (
   if $ssh_sendenv == 'USE_DEFAULTS' {
     $ssh_sendenv_real = $default_ssh_sendenv
   } else {
+    if $ssh_sendenv_string {
+      validate_string($ssh_sendenv_string)
+    }
     case type3x($ssh_sendenv) {
       'string': {
         validate_re($ssh_sendenv, '^(true|false)$', "ssh::ssh_sendenv may be either 'true' or 'false' and is set to <${ssh_sendenv}>.")
@@ -424,6 +429,9 @@ class ssh (
   if $sshd_acceptenv == 'USE_DEFAULTS' {
     $sshd_acceptenv_real = $default_sshd_acceptenv
   } else {
+    if $ssh_acceptenv_string {
+      validate_string($ssh_acceptenv_string)
+    }
     case type3x($sshd_acceptenv) {
       'string': {
         validate_re($sshd_acceptenv, '^(true|false)$', "ssh::sshd_acceptenv may be either 'true' or 'false' and is set to <${sshd_acceptenv}>.")

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -102,7 +102,6 @@ GSSAPIDelegateCredentials <%= @ssh_gssapidelegatecredentials %>
 # Send custom locale-related environment variables
   SendEnv <%= @ssh_sendenv_string %>
 <% end -%>
-<% end -%>
 <% if @ssh_config_macs -%>
   MACs <%= @ssh_config_macs.join(',') %>
 <% end -%>

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -90,11 +90,15 @@ GSSAPIDelegateCredentials <%= @ssh_gssapidelegatecredentials %>
 <% if @ssh_config_server_alive_interval != nil -%>
   ServerAliveInterval <%= @ssh_config_server_alive_interval %>
 <% end -%>
-<% if @ssh_sendenv_real == true -%>
+<% if (@ssh_sendenv_real == true) and !(@ssh_sendenv_string) -%>
 # Send locale-related environment variables
   SendEnv LANG LANGUAGE LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
   SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
   SendEnv LC_IDENTIFICATION LC_ALL
+<% elsif @ssh_sendenv_string -%>
+# Send custom locale-related environment variables
+  SendEnv <%= @ssh_sendenv_string %>
+<% end -%>
 <% if @ssh_config_sendenv_xmodifiers_real == true -%>
   SendEnv XMODIFIERS
 <% end -%>

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -95,12 +95,12 @@ GSSAPIDelegateCredentials <%= @ssh_gssapidelegatecredentials %>
   SendEnv LANG LANGUAGE LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
   SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
   SendEnv LC_IDENTIFICATION LC_ALL
+<% if @ssh_config_sendenv_xmodifiers_real == true -%>
+  SendEnv XMODIFIERS
+<% end -%>
 <% elsif @ssh_sendenv_string -%>
 # Send custom locale-related environment variables
   SendEnv <%= @ssh_sendenv_string %>
-<% end -%>
-<% if @ssh_config_sendenv_xmodifiers_real == true -%>
-  SendEnv XMODIFIERS
 <% end -%>
 <% end -%>
 <% if @ssh_config_macs -%>

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -90,7 +90,7 @@ GSSAPIDelegateCredentials <%= @ssh_gssapidelegatecredentials %>
 <% if @ssh_config_server_alive_interval != nil -%>
   ServerAliveInterval <%= @ssh_config_server_alive_interval %>
 <% end -%>
-<% if (@ssh_sendenv_real == true) and !(@ssh_sendenv_string) -%>
+<% if (@ssh_sendenv_real == true) and (@ssh_sendenv_string == nil) -%>
 # Send locale-related environment variables
   SendEnv LANG LANGUAGE LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
   SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -90,7 +90,7 @@ GSSAPIDelegateCredentials <%= @ssh_gssapidelegatecredentials %>
 <% if @ssh_config_server_alive_interval != nil -%>
   ServerAliveInterval <%= @ssh_config_server_alive_interval %>
 <% end -%>
-<% if (@ssh_sendenv_real == true) and (@ssh_sendenv_string == nil) -%>
+<% if (@ssh_sendenv_real == true) and !(@ssh_sendenv_string) -%>
 # Send locale-related environment variables
   SendEnv LANG LANGUAGE LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
   SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -151,7 +151,7 @@ GSSAPICleanupCredentials <%= @sshd_gssapicleanupcredentials_real %>
 UsePAM <%= @sshd_use_pam_real %>
 <% end -%>
 
-<% if @sshd_acceptenv_real == true and !(@ssh_acceptenv_string) -%>
+<% if @sshd_acceptenv_real == true and (@ssh_acceptenv_string == nil) -%>
 # Accept locale-related environment variables
 AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
 AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -151,11 +151,14 @@ GSSAPICleanupCredentials <%= @sshd_gssapicleanupcredentials_real %>
 UsePAM <%= @sshd_use_pam_real %>
 <% end -%>
 
-<% if @sshd_acceptenv_real == true -%>
+<% if @sshd_acceptenv_real == true and !(@ssh_acceptenv_string) -%>
 # Accept locale-related environment variables
 AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
 AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
 AcceptEnv LC_IDENTIFICATION LC_ALL
+<% elsif @ssh_acceptenv_string -%>
+# Accept custom locale-related environment variables
+  AcceptEnv <%= @ssh_acceptenv_string %>
 <% end -%>
 #AllowTcpForwarding yes
 AllowTcpForwarding <%= @sshd_allow_tcp_forwarding %>

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -151,14 +151,14 @@ GSSAPICleanupCredentials <%= @sshd_gssapicleanupcredentials_real %>
 UsePAM <%= @sshd_use_pam_real %>
 <% end -%>
 
-<% if @sshd_acceptenv_real == true and (@ssh_acceptenv_string == nil) -%>
+<% if @sshd_acceptenv_real == true and !(@sshd_acceptenv_string) -%>
 # Accept locale-related environment variables
 AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
 AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
 AcceptEnv LC_IDENTIFICATION LC_ALL
-<% elsif @ssh_acceptenv_string -%>
+<% elsif @sshd_acceptenv_string -%>
 # Accept custom locale-related environment variables
-  AcceptEnv <%= @ssh_acceptenv_string %>
+  AcceptEnv <%= @sshd_acceptenv_string %>
 <% end -%>
 #AllowTcpForwarding yes
 AllowTcpForwarding <%= @sshd_allow_tcp_forwarding %>


### PR DESCRIPTION
Added `sshd_acceptenv_string` and `ssh_sendenv_string` params, to add custom AcceptEnv/SendEnv strings.
Some software need another parameters, like `LANG LC_*`, (like Proxmox VE: https://forum.proxmox.com/threads/pve-4-3-console-access-on-different-cluster-member.29733/page-2 )