### PR TITLE
Add ssh::config_entry defined type

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ ssh_key_ensure and purge_keys.
 
 This module may be used with a simple `include ::ssh`
 
+The `ssh::config_entry` defined type may be used directly and is used to manage
+Host entries in a personal `~/.ssh/config` file.
+
 ===
 
 ### Table of Contents
@@ -851,4 +854,31 @@ ssh::keys:
   root_for_userY:
     ensure: absent
     user: root
+```
+
+Manage config entries in a personal ssh/config file.
+
+```
+Ssh::Config_entry {
+  ensure => present,
+  path   => '/home/jenkins/.ssh/config',
+  owner  => 'jenkins',
+  group  => 'jenkins',
+}
+
+
+ssh::config_entry { 'jenkins *':
+  host  => '*',
+  lines => [
+    '  ForwardX11 no',
+    '  StrictHostKeyChecking no',
+  ],
+  order => '10',
+}
+
+ssh::config_entry { 'jenkins github.com':
+  host  => 'github.com',
+  lines => ["  IdentityFile /home/jenkins/.ssh/jenkins-gihub.key"],
+  order => '20',
+}
 ```

--- a/manifests/config_entry.pp
+++ b/manifests/config_entry.pp
@@ -1,0 +1,36 @@
+# == Define: ssh::config_entry
+#
+# Manage an entry in ~/.ssh/config for a particular user.  Lines model the lines
+# in each Host block.
+define ssh::config_entry (
+  $owner,
+  $group,
+  $path,
+  $host,
+  $order  = '10',
+  $ensure = 'present',
+  $lines  = [],
+) {
+
+  # All lines including the host line.  This will be joined with "\n  " for
+  # indentation.
+  $entry = concat(["Host ${host}"], $lines)
+  $content = join($entry, "\n")
+
+  if ! defined(Concat[$path]) {
+    concat { $path:
+      ensure         => present,
+      owner          => $owner,
+      group          => $group,
+      mode           => '0644',
+      ensure_newline => true,
+    }
+  }
+
+  concat::fragment { "${path} Host ${host}":
+    target  => $path,
+    content => $content,
+    order   => $order,
+    tag     => "${owner}_ssh_config",
+  }
+}


### PR DESCRIPTION
This patch adds a mechanism to manage ~/.ssh/config entries using the
concat module.