### PR TITLE
Add sshd_config_authenticationmethods parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,12 @@ String for IgnoreUserKnownHosts option in sshd_config. Valid values are 'yes' an
 
 - *Default*: 'no'
 
+sshd_config_authenticationmethods
+-------------------------
+Array of AuthenticationMethods in sshd_config.
+
+- *Default*: undef
+
 sshd_ignorerhosts
 -------------------------
 String for IgnoreRhosts option in sshd_config. Valid values are 'yes' and 'no'. Specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication though /etc/hosts.equiv and /etc/ssh/shosts.equiv are still used.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,6 +93,7 @@ class ssh (
   $sshd_pubkeyauthentication              = 'yes',
   $sshd_ignoreuserknownhosts              = 'no',
   $sshd_ignorerhosts                      = 'yes',
+  $sshd_config_authenticationmethods      = undef,
   $manage_service                         = true,
   $sshd_addressfamily                     = 'USE_DEFAULTS',
   $service_ensure                         = 'running',
@@ -667,6 +668,10 @@ class ssh (
 
   if $sshd_pubkeyacceptedkeytypes != undef {
     validate_array($sshd_pubkeyacceptedkeytypes)
+  }
+
+  if $sshd_config_authenticationmethods != undef {
+    validate_array($sshd_config_authenticationmethods)
   }
 
   validate_re($sshd_pubkeyauthentication, '^(yes|no)$', "ssh::sshd_pubkeyauthentication may be either 'yes' or 'no' and is set to <${sshd_pubkeyauthentication}>.")

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -419,6 +419,9 @@ describe 'ssh' do
                                                    'ssh-ed25519',
                                                    'ssh-rsa',
         ],
+        :sshd_config_authenticationmethods    => [ 'publickey',
+                                                   'keyboard-interactive',
+        ],
         :sshd_pubkeyauthentication            => 'no',
         :sshd_allow_tcp_forwarding            => 'no',
         :sshd_x11_forwarding                  => 'no',
@@ -526,6 +529,7 @@ describe 'ssh' do
     it { should contain_file('sshd_config').with_content(/^AuthorizedKeysCommandUser asdf$/) }
     it { should contain_file('sshd_config').with_content(/^HostbasedAuthentication no$/) }
     it { should contain_file('sshd_config').with_content(/^PubkeyAcceptedKeyTypes ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,ssh-rsa$/) }
+    it { should contain_file('sshd_config').with_content(/^AuthenticationMethods publickey,keyboard-interactive$/) }
     it { should contain_file('sshd_config').with_content(/^PubkeyAuthentication no$/) }
     it { should contain_file('sshd_config').with_content(/^IgnoreUserKnownHosts no$/) }
     it { should contain_file('sshd_config').with_content(/^IgnoreRhosts yes$/) }
@@ -2392,6 +2396,18 @@ describe 'sshd_config_print_last_log param' do
   [true,'invalid'].each do |pubkeyacceptedkeytypes|
     context "with sshd_pubkeyacceptedkeytypes set to invalid value #{pubkeyacceptedkeytypes}" do
       let(:params) { { :sshd_pubkeyacceptedkeytypes => pubkeyacceptedkeytypes } }
+
+      it 'should fail' do
+        expect {
+          should contain_class('ssh')
+        }.to raise_error(Puppet::Error,/is not/)
+      end
+    end
+  end
+
+  [true,'invalid'].each do |authenticationmethods|
+    context "with sshd_config_authenticationmethods set to invalid value #{authenticationmethods}" do
+      let(:params) { { :sshd_config_authenticationmethods => authenticationmethods } }
 
       it 'should fail' do
         expect {

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -98,6 +98,9 @@ IgnoreUserKnownHosts <%= @sshd_ignoreuserknownhosts %>
 #IgnoreRhosts yes
 IgnoreRhosts <%= @sshd_ignorerhosts %>
 
+<%- if @sshd_config_authenticationmethods -%>
+AuthenticationMethods <%= @sshd_config_authenticationmethods.join(',') %>
+<%- end -%>
 # To disable tunneled clear text passwords, change to no here!
 #PasswordAuthentication yes
 PasswordAuthentication <%= @sshd_password_authentication %>


### PR DESCRIPTION
This commit adds support for AuthenticationMethods by adding the
sshd_config_authenticationmethods parameter. Credits to @Saford91 for
the first implementation.