### PR TITLE
make ssh key export conditional with new boolean ssh_key_export

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ X11Forwarding in sshd_config. Specifies whether X11 forwarding is permitted.
 
 sshd_x11_use_localhost
 ----------------------
-X11UseLocalhost in sshd_config. Specifies if sshd should bind the X11 forwarding server 
+X11UseLocalhost in sshd_config. Specifies if sshd should bind the X11 forwarding server
 to the loopback address or to the wildcard address.
 
 - *Default*: 'yes'
@@ -792,9 +792,15 @@ Boolean to declare whether the service's init script has a functional status com
 
 ssh_key_ensure
 --------------
-Export node SSH key. Valid values are 'present' and 'absent'.
+Export node SSH key. Valid values are 'present' and 'absent'. Requires ssh_key_export set to 'true'.
 
 - *Default*: 'present'
+
+ssh_key_export
+--------------
+Manage node SSH key with exported resources. Valid values are 'true' and 'false'.
+
+- *Default*: 'true'
 
 ssh_key_import
 --------------

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2375,8 +2375,6 @@ describe 'sshd_config_print_last_log param' do
         it { should compile.with_all_deps }
 
         it { should contain_class('ssh') }
-
-        it { should_not contain_resources('sshkey') }
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2375,6 +2375,12 @@ describe 'sshd_config_print_last_log param' do
         it { should compile.with_all_deps }
 
         it { should contain_class('ssh') }
+
+        context "as an exported resource" do
+            subject { exported_resources }
+
+            it { should_not contain_resources('sshkey') }
+        end
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2335,6 +2335,52 @@ describe 'sshd_config_print_last_log param' do
     end
   end
 
+  describe 'with ssh_key_export parameter specified' do
+    context 'as a non-boolean or non-string' do
+    let(:params) { { :ssh_key_export => ['not_a_boolean','or_a_string'] } }
+
+      it 'should fail' do
+        expect {
+          should contain_class('ssh')
+        }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context 'as an invalid string' do
+      let(:params) { { :ssh_key_export => 'invalid_string' } }
+
+      it 'should fail' do
+        expect {
+          should contain_class('ssh')
+        }.to raise_error(Puppet::Error,/ssh::ssh_key_export may be either 'true' or 'false' and is set to <invalid_string>\./)
+      end
+    end
+
+    ['true',true].each do |value|
+      context "as #{value}" do
+        let(:params) { { :ssh_key_export => value } }
+
+        it { should compile.with_all_deps }
+
+        it { should contain_class('ssh') }
+
+        it { should contain_resources('sshkey') }
+      end
+    end
+
+    ['false',false].each do |value|
+      context "as #{value}" do
+        let(:params) { { :ssh_key_export => value } }
+
+        it { should compile.with_all_deps }
+
+        it { should contain_class('ssh') }
+
+        it { should_not contain_resources('sshkey') }
+      end
+    end
+  end
+
   describe 'with ssh_key_import parameter specified' do
     context 'as a non-boolean or non-string' do
     let(:params) { { :ssh_key_import => ['not_a_boolean','or_a_string'] } }


### PR DESCRIPTION
Currently a warning is displayed on systems that do not support exported resources (have no PuppetDB).
This pull request adds an option that allows the user to disable exporting the ssh key so the warning is not displayed.

For backwards compatibility the new parameter `ssh_key_export`is set to `true` by default which enables exporting the ssh key.

Closes #229, #235