### PR TITLE
Make it possible to use internal defaults of sshd to determine hostkey

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -442,12 +442,14 @@ class ssh (
     }
   }
 
-  if $sshd_config_hostkey == 'USE_DEFAULTS' {
-    $sshd_config_hostkey_real = $default_sshd_config_hostkey
-  } else {
-    validate_array($sshd_config_hostkey)
-    validate_absolute_path($sshd_config_hostkey)
-    $sshd_config_hostkey_real = $sshd_config_hostkey
+  if $sshd_config_hostkey != undef {
+    if $sshd_config_hostkey == 'USE_DEFAULTS' {
+      $sshd_config_hostkey_real = $default_sshd_config_hostkey
+    } else {
+      validate_array($sshd_config_hostkey)
+      validate_absolute_path($sshd_config_hostkey)
+      $sshd_config_hostkey_real = $sshd_config_hostkey
+    }
   }
 
   if $sshd_listen_address {

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -36,8 +36,10 @@ ListenAddress <%= @sshd_listen_address %>
 # HostKeys for protocol version 2
 #HostKey /etc/ssh/ssh_host_rsa_key
 #HostKey /etc/ssh/ssh_host_dsa_key
+<% if @sshd_config_hostkey_real %>
 <% @sshd_config_hostkey_real.each do |hostkey| -%>
 HostKey <%= hostkey %>
+<% end -%>
 <% end -%>
 
 # Lifetime and size of ephemeral version 1 server key


### PR DESCRIPTION
Use case: We want to use the internal defaults of `sshd` when it comes to choose the appropriate `hostkey`.
When we use this `ssh` module with the default parameters it might configure the wrong keys if there is no proper default defined in `init.pp`. This happens on SLES 12 and EL 7. Clients that were connected to an affected host before the puppet run will receive an error that the remote host identification has changed afterwards.