### PR TITLE
Correct obsolete ServerKeyBits sshd_config option on CentOS 7.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,7 +143,7 @@ class ssh (
       $default_sshd_gssapicleanupcredentials   = 'yes'
       $default_sshd_acceptenv                  = true
       $default_service_hasstatus               = true
-      if $::operatingsystemrelease == '7.4' {
+      if $::operatingsystemrelease =~ /^7\./ {
         $default_sshd_config_serverkeybits     = undef
       } else {
         $default_sshd_config_serverkeybits     = '1024'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,7 +143,11 @@ class ssh (
       $default_sshd_gssapicleanupcredentials   = 'yes'
       $default_sshd_acceptenv                  = true
       $default_service_hasstatus               = true
-      $default_sshd_config_serverkeybits       = '1024'
+      if $::operatingsystemrelease == '7.4' {
+        $default_sshd_config_serverkeybits     = undef
+      } else {
+        $default_sshd_config_serverkeybits     = '1024'
+      }
       $default_sshd_config_hostkey             = [ '/etc/ssh/ssh_host_rsa_key' ]
       $default_sshd_addressfamily              = 'any'
       $default_sshd_config_tcp_keepalive       = 'yes'


### PR DESCRIPTION
This commit fixes https://github.com/ghoneycutt/puppet-module-ssh/issues/244.

This is achieved using the creator's advice of using a conditional. No further changes to the code are made.