### PR TITLE
Fixing an inaccuracy within README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ PrintMotd option in sshd_config.
 
 - *Default*: 'yes'
 
-sshd_config_print_lastlog
+sshd_config_print_last_log
 ----------------------
 PrintLastLog option in sshd_config.
 Verify SSH provides users with feedback on when account accesses last occurred.


### PR DESCRIPTION
README.md incorrectly lists the parameter for configuring the PrintLastLog sshd_config option as "sshd_config_print_lastlog" when in actuality the parameter is, "sshd_config_print_last_log" 