### PR TITLE
Prevent conversion warning

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -284,8 +284,13 @@ class ssh (
 
   if "${::ssh_version}" =~ /^OpenSSH/  { # lint:ignore:only_variable_string
     $ssh_version_array = split($::ssh_version_numeric, '\.')
-    $ssh_version_maj_int = 0 + $ssh_version_array[0]
-    $ssh_version_min_int = 0 + $ssh_version_array[1]
+    if versioncmp($::serverversion, '4.4') {
+      $ssh_version_maj_int = Integer($ssh_version_array[0])
+      $ssh_version_min_int = Integer($ssh_version_array[1])
+    } else {
+      $ssh_version_maj_int = 0 + $ssh_version_array[0]
+      $ssh_version_min_int = 0 + $ssh_version_array[1]
+    }
     if $ssh_version_maj_int > 5 {
       $default_ssh_config_use_roaming = 'no'
     } elsif $ssh_version_maj_int == 5 and $ssh_version_min_int >= 4 {


### PR DESCRIPTION
The code generates a warning 
```
Puppet The string '7' was automatically coerced to the numerical value 7 at.../ssh/manifests/init.pp:288:32
Puppet The string '6' was automatically coerced to the numerical value 6 at .../ssh/manifests/init.pp:287:32
```
Since 4.5 one should use the type new function, the document is in the process of being updated
https://tickets.puppetlabs.com/browse/DOCUMENT-817?focusedCommentId=533239&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-533239
https://github.com/puppetlabs/puppet-docs/commit/eec0033fabb95409a612cf1cb3ab39340cfcb052#diff-b0c80cf31b92d3db142070174f496a8b