### PR TITLE
Add support for prohibit-password

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -725,11 +725,11 @@ class ssh (
   }
 
   case $permit_root_login {
-    'no', 'yes', 'without-password', 'forced-commands-only': {
+    'no', 'yes', 'without-password', 'prohibit-password', 'forced-commands-only': {
       # noop
     }
     default: {
-      fail("ssh::permit_root_login may be either 'yes', 'without-password', 'forced-commands-only' or 'no' and is set to <${permit_root_login}>.")
+      fail("ssh::permit_root_login may be either 'yes', 'without-password', 'prohibit-password', 'forced-commands-only' or 'no' and is set to <${permit_root_login}>.")
     }
   }
 


### PR DESCRIPTION
```PermitRootLogin prohibit-password``` is now permitted by the validator.  No spec test, there wasn't one for the existing validator.  Works on a vm.    Non-breaking change.