### PR TITLE
Update to support ed25519

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -741,10 +741,13 @@ class ssh (
       $key = $::sshdsakey
     }
     'ecdsa-sha2-nistp256': {
-          $key = $::sshecdsakey
+      $key = $::sshecdsakey
+    }
+    'ssh-ed25519': {
+      $key = $::sshed25519key
     }
     default: {
-      fail("ssh::ssh_key_type must be 'ecdsa-sha2-nistp256', 'ssh-rsa', 'rsa', 'ssh-dsa', or 'dsa' and is <${ssh_key_type}>.")
+      fail("ssh::ssh_key_type must be 'ecdsa-sha2-nistp256', 'ssh-ed25519', 'ssh-rsa', 'rsa', 'ssh-dsa', or 'dsa' and is <${ssh_key_type}>.")
     }
   }
 


### PR DESCRIPTION
There's a host key validator that didn't have a case for ed25519.  It now does.  No spec test (there wasn't for the rest of the case block) but it has been tested on a vm and works.  Non-breaking change.