### PR TITLE
Add RevokedKeys option to sshd_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,12 @@ Absolute path to the OpenSSH User CA Certificate (TrustedUserCAKeys) for use wit
 
 - *Default*: undefined
 
+sshd_config_key_revocation_list
+-----------------------------
+Absolute path to a key revocation list (RevokedKeys) for use with SSH CA Validation for Users or the string 'none'.
+
+- *Default*: undefined
+
 sshd_config_authorized_principals_file
 --------------------------------------
 String path (relative or absolute) to the `authorized_principals` file. Sets the `AuthorizedPrincipalsFile` setting in `sshd_config`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,6 +119,7 @@ class ssh (
   $sshd_config_permittunnel               = undef,
   $sshd_config_hostcertificate            = undef,
   $sshd_config_trustedusercakeys          = undef,
+  $sshd_config_key_revocation_list        = undef,
   $sshd_config_authorized_principals_file = undef,
   $sshd_config_allowagentforwarding       = undef,
 ) {
@@ -508,6 +509,11 @@ class ssh (
     default: { $sshd_config_trustedusercakeys_real = $sshd_config_trustedusercakeys }
   }
 
+  case $sshd_config_key_revocation_list {
+    'unset', undef: { $sshd_config_key_revocation_list_real = undef }
+    default: { $sshd_config_key_revocation_list_real = $sshd_config_key_revocation_list }
+  }
+
   case $sshd_config_authorized_principals_file {
     'unset', undef: { $sshd_config_authorized_principals_file_real = undef }
     default: { $sshd_config_authorized_principals_file_real = $sshd_config_authorized_principals_file }
@@ -869,6 +875,12 @@ class ssh (
     # TrustedUserCAKeys may be a path to the keys or 'none'
     if $sshd_config_trustedusercakeys_real != 'none' {
       validate_absolute_path($sshd_config_trustedusercakeys_real)
+    }
+  }
+  if $sshd_config_key_revocation_list_real != undef {
+    # RevokedKeys may be a path to the key revocation list or 'none'
+    if $sshd_config_key_revocation_list_real != 'none' {
+      validate_absolute_path($sshd_config_key_revocation_list)
     }
   }
 

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -280,6 +280,9 @@ HostCertificate <%= @sshd_config_hostcertificate_real %>
 <% if @sshd_config_trustedusercakeys_real -%>
 TrustedUserCAKeys <%= @sshd_config_trustedusercakeys_real %>
 <% end -%>
+<% if @sshd_config_key_revocation_list_real -%>
+RevokedKeys <%= @sshd_config_key_revocation_list_real %>
+<% end -%>
 <% if @sshd_config_authorized_principals_file_real -%>
 AuthorizedPrincipalsFile <%= @sshd_config_authorized_principals_file_real %>
 <% end -%>


### PR DESCRIPTION
Added $sshd_config_key_revocation_list to init.pp and sshd_config.erb

Controls creation of RevokedKeys parameter in sshd_config.

for use with the TrustedUserCAKeys option.

Tested on rhel 6 and 7