### PR TITLE
Unset ServerKeyBits for Ubuntu 18.04 hosts as it is deprecated

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -202,10 +202,20 @@ class ssh (
         ]
         $default_ssh_config_hash_known_hosts     = 'yes'
         $default_sshd_config_xauth_location      = undef
+        $default_sshd_config_serverkeybits       = '1024'
+      } elsif $::operatingsystemrelease == '18.04' {
+        $default_sshd_config_hostkey             = [
+          '/etc/ssh/ssh_host_rsa_key',
+          '/etc/ssh/ssh_host_dsa_key',
+          '/etc/ssh/ssh_host_ecdsa_key',
+          '/etc/ssh/ssh_host_ed25519_key',
+        ]
+        $default_sshd_config_serverkeybits       = undef
       } else {
         $default_sshd_config_hostkey             = [ '/etc/ssh/ssh_host_rsa_key' ]
         $default_ssh_config_hash_known_hosts     = 'no'
         $default_sshd_config_xauth_location      = '/usr/bin/xauth'
+        $default_sshd_config_serverkeybits       = '1024'
       }
       $default_packages                        = ['openssh-server',
                                                   'openssh-client']
@@ -223,7 +233,6 @@ class ssh (
       $default_sshd_gssapicleanupcredentials   = 'yes'
       $default_sshd_acceptenv                  = true
       $default_service_hasstatus               = true
-      $default_sshd_config_serverkeybits       = '1024'
       $default_sshd_addressfamily              = 'any'
       $default_sshd_config_tcp_keepalive       = 'yes'
       $default_sshd_config_permittunnel        = 'no'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -219,6 +219,17 @@ describe 'ssh' do
       :sshd_config_fixture    => 'sshd_config_ubuntu1604',
       :ssh_config_fixture     => 'ssh_config_ubuntu1604',
     },
+    'Ubuntu-1804' => {
+      :architecture           => 'x86_64',
+      :osfamily               => 'Debian',
+      :operatingsystemrelease => '18.04',
+      :ssh_version            => 'OpenSSH_7.6p1',
+      :ssh_version_numeric    => '7.6',
+      :ssh_packages           => ['openssh-server', 'openssh-client'],
+      :sshd_config_mode       => '0600',
+      :sshd_service_name      => 'ssh',
+      :sshd_service_hasstatus => true,
+    },
   }
 
   osfamily_matrix.each do |os, facts|


### PR DESCRIPTION
Hi,

it's close to #244: when putting `ServerKeyBits` config in `sshd_config` on an Ubuntu 18.04 machine, puppet run fails (using ghoneycutt-ssh (v3.59.0)).

````
Jan 24 13:12:53 lnv-2065 systemd[1]: Stopped OpenBSD Secure Shell server.
Jan 24 13:12:53 lnv-2065 systemd[1]: Starting OpenBSD Secure Shell server...
Jan 24 13:12:53 lnv-2065 sshd[2142]: /etc/ssh/sshd_config line 33: Deprecated option ServerKeyBits
````

I just hacked your code a bit and at least in my environment everything works fine now; please review or add Ubuntu-18.01 support your way :)

Cheers,
  Marianne