### PR TITLE
Add for the possibility of an IPv6 address

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -974,10 +974,18 @@ class ssh (
     }
   }
 
+  # If either IPv4 or IPv6 stack is not configured on the agent, the
+  # corresponding $::ipaddress(6)? fact is not present. So, we cannot assume
+  # these variables are defined. Getvar (Stdlib 4.13+, ruby 1.8.7+) handles
+  # this correctly.
+  if getvar('::ipaddress') and getvar('::ipaddress6') { $host_aliases = [$::hostname, $::ipaddress, $::ipaddress6] }
+  elsif getvar('::ipaddress6') { $host_aliases = [$::hostname, $::ipaddress6] }
+  else { $host_aliases = [$::hostname, $::ipaddress] }
+
   # export each node's ssh key
   @@sshkey { $::fqdn :
     ensure       => $ssh_key_ensure,
-    host_aliases => [$::hostname, $::ipaddress],
+    host_aliases => $host_aliases,
     type         => $ssh_key_type,
     key          => $key,
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -311,6 +311,32 @@ describe 'ssh' do
       }
 
       it { should have_ssh__config_entry_resource_count(0) }
+
+      context 'with exported sshkey resources' do
+        subject { exported_resources}
+        context 'With only IPv4 address' do
+          let(:facts) { default_facts.merge( facts )}
+          it { should contain_sshkey('monkey.example.com').with(
+            'ensure' => 'present',
+            'host_aliases' => ['monkey', '127.0.0.1']
+          )}
+        end
+        context 'With dual stack IP' do
+          let(:facts) { default_facts.merge({ :ipaddress6 => 'dead:beef::1/64' }) }
+          it { should contain_sshkey('monkey.example.com').with(
+            'ensure' => 'present',
+            'host_aliases' => ['monkey', '127.0.0.1', 'dead:beef::1/64']
+          )}
+        end
+        context 'With only IPv6 address' do
+          let(:facts) { default_facts.merge({ :ipaddress6 => 'dead:beef::1/64', :ipaddress => nil }) }
+          it { should contain_sshkey('monkey.example.com').with(
+            'ensure' => 'present',
+            'host_aliases' => ['monkey', 'dead:beef::1/64']
+          )}
+        end
+      end
+
     end
   end
 


### PR DESCRIPTION
Also cover the case that there is no IPv4 address on an IPv6 only host.

Fixes #308. Tested with 2 Centos7 hosts running Puppet5.5 One of them has only IPv6, the other one is dual homed. The resulting known_hosts file contains the correct amount of IP addresses.