### PR TITLE
Allow 'local' and 'remote' for AllowTcpForwarding

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -679,7 +679,7 @@ class ssh (
     validate_re($sshd_kerberos_authentication, '^(yes|no)$', "ssh::sshd_kerberos_authentication may be either 'yes' or 'no' and is set to <${sshd_kerberos_authentication}>.")
   }
   validate_re($sshd_password_authentication, '^(yes|no)$', "ssh::sshd_password_authentication may be either 'yes' or 'no' and is set to <${sshd_password_authentication}>.")
-  validate_re($sshd_allow_tcp_forwarding, '^(yes|no)$', "ssh::sshd_allow_tcp_forwarding may be either 'yes' or 'no' and is set to <${sshd_allow_tcp_forwarding}>.")
+  validate_re($sshd_allow_tcp_forwarding, '^(yes|no|local|remote)$', "ssh::sshd_allow_tcp_forwarding may be either 'yes', 'no', 'local' or 'remote' and is set to <${sshd_allow_tcp_forwarding}>.")
   validate_re($sshd_x11_forwarding, '^(yes|no)$', "ssh::sshd_x11_forwarding may be either 'yes' or 'no' and is set to <${sshd_x11_forwarding}>.")
   validate_re($sshd_x11_use_localhost, '^(yes|no)$', "ssh::sshd_x11_use_localhost may be either 'yes' or 'no' and is set to <${sshd_x11_use_localhost}>.")
   if $sshd_config_print_last_log != undef {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1269,13 +1269,23 @@ describe 'sshd_config_print_last_log param' do
     end
   end
 
-  context 'with sshd_allow_tcp_forwarding set to invalid value on valid osfamily' do
-    let(:params) { { :sshd_allow_tcp_forwarding => 'invalid' } }
+  describe 'sshd_allow_tcp_forwarding param' do
+    ['yes', 'no', 'local', 'remote'].each do |value|
+      context "set to #{value}" do
+        let (:params) { { :sshd_allow_tcp_forwarding => value } }
 
-    it 'should fail' do
-      expect {
-        should contain_class('ssh')
-      }.to raise_error(Puppet::Error,/ssh::sshd_allow_tcp_forwarding may be either \'yes\' or \'no\' and is set to <invalid>\./)
+        it { should contain_file('sshd_config').with_content(/^AllowTcpForwarding #{value}/) }
+      end
+    end
+
+    context 'set to invalid' do
+      let(:params) { { :sshd_allow_tcp_forwarding => 'invalid' } }
+
+      it 'should fail' do
+        expect {
+          should contain_class('ssh')
+        }.to raise_error(Puppet::Error,/ssh::sshd_allow_tcp_forwarding may be either \'yes\', \'no\', \'local\' or \'remote\' and is set to <invalid>\./)
+      end
     end
   end
 


### PR DESCRIPTION
This change allows usage of  'local' and 'remote' for the option AllowTcpForwarding