### PR TITLE
Unset default_sshd_config_serverkeybits for Ubuntu 18.04

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -248,7 +248,7 @@ class ssh (
           $default_sshd_gssapicleanupcredentials      = 'yes'
           $default_sshd_acceptenv                     = true
           $default_service_hasstatus                  = true
-          $          = undef
+          $default_sshd_config_serverkeybits          = undef
           $default_sshd_addressfamily                 = 'any'
           $default_sshd_config_tcp_keepalive          = 'yes'
           $default_sshd_config_permittunnel           = 'no'
@@ -267,9 +267,9 @@ class ssh (
           $default_ssh_config_hash_known_hosts     = 'yes'
           $default_ssh_sendenv                     = true
           $default_sshd_addressfamily              = undef
-          $default_sshd_config_serverkeybits       = undef
+          $default_sshd_config_use_dns             = undef
           $default_sshd_gssapicleanupcredentials   = undef
-          $default_default_sshd_config_serverkeybitssshd_config_use_dns             = undef
+          $default_sshd_config_use_dns             = undef
           $default_sshd_config_xauth_location      = undef
           $default_sshd_config_permittunnel        = undef
           $default_sshd_config_tcp_keepalive       = undef

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -267,7 +267,7 @@ class ssh (
           $default_ssh_config_hash_known_hosts     = 'yes'
           $default_ssh_sendenv                     = true
           $default_sshd_addressfamily              = undef
-          $default_sshd_config_use_dns             = undef
+          $default_sshd_config_serverkeybits       = undef
           $default_sshd_gssapicleanupcredentials   = undef
           $default_sshd_config_use_dns             = undef
           $default_sshd_config_xauth_location      = undef

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -248,7 +248,7 @@ class ssh (
           $default_sshd_gssapicleanupcredentials      = 'yes'
           $default_sshd_acceptenv                     = true
           $default_service_hasstatus                  = true
-          $default_sshd_config_serverkeybits          = '1024'
+          $          = undef
           $default_sshd_addressfamily                 = 'any'
           $default_sshd_config_tcp_keepalive          = 'yes'
           $default_sshd_config_permittunnel           = 'no'
@@ -269,7 +269,7 @@ class ssh (
           $default_sshd_addressfamily              = undef
           $default_sshd_config_serverkeybits       = undef
           $default_sshd_gssapicleanupcredentials   = undef
-          $default_sshd_config_use_dns             = undef
+          $default_default_sshd_config_serverkeybitssshd_config_use_dns             = undef
           $default_sshd_config_xauth_location      = undef
           $default_sshd_config_permittunnel        = undef
           $default_sshd_config_tcp_keepalive       = undef


### PR DESCRIPTION
Ubuntu 18.04's version of SSH deprecated the ServerKeyBits setting - so we should not be setting it.