### PR TITLE
#314 Restore defaults for Ubuntu 12.04 and 14.04

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -205,7 +205,7 @@ class ssh (
       $default_service_name                    = 'ssh'
 
       case $::operatingsystemrelease {
-        /^1[24].04$/: {
+        /^1[24]\.04$/: {
           $default_sshd_config_hostkey                = [ '/etc/ssh/ssh_host_rsa_key' ]
           $default_ssh_config_hash_known_hosts        = 'no'
           $default_sshd_config_xauth_location         = '/usr/bin/xauth'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -199,6 +199,28 @@ class ssh (
       $default_service_name                    = 'ssh'
 
       case $::operatingsystemrelease {
+        /^1[24].04$/: {
+          $default_sshd_config_hostkey                = [ '/etc/ssh/ssh_host_rsa_key' ]
+          $default_ssh_config_hash_known_hosts        = 'no'
+          $default_sshd_config_xauth_location         = '/usr/bin/xauth'
+          $default_ssh_config_forward_x11_trusted     = 'yes'
+          $default_ssh_package_source                 = undef
+          $default_ssh_package_adminfile              = undef
+          $default_ssh_sendenv                        = true
+          $default_sshd_config_subsystem_sftp         = '/usr/lib/openssh/sftp-server'
+          $default_sshd_config_mode                   = '0600'
+          $default_sshd_config_use_dns                = 'yes'
+          $default_sshd_use_pam                       = 'yes'
+          $default_sshd_gssapikeyexchange             = undef
+          $default_sshd_pamauthenticationviakbdint    = undef
+          $default_sshd_gssapicleanupcredentials      = 'yes'
+          $default_sshd_acceptenv                     = true
+          $default_service_hasstatus                  = true
+          $default_sshd_config_serverkeybits          = '1024'
+          $default_sshd_addressfamily                 = 'any'
+          $default_sshd_config_tcp_keepalive          = 'yes'
+          $default_sshd_config_permittunnel           = 'no'
+        }
         '16.04': {
           $default_sshd_config_hostkey = [
             '/etc/ssh/ssh_host_rsa_key',


### PR DESCRIPTION
Added an $operatingsystemrelease case to restore Ubuntu 12.04 and 14.04 compatitibility.
Values based off defaults originally in 9832dee0a07d82e6f2f215fce10149fbb24aa573