### PR TITLE
Made host_aliases configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,16 @@ forwarding is permitted. Valid values are 'yes' and 'no'.
 
 - *Default*: undef
 
+host_aliases
+------------
+Add custom host aliases. When none is provided, the host_alias will be:
+```
+FQDN,SHORT_HOSTNAME,IPADDRESS
+```
+
+- *Default*: undef
+
+
 config_entries
 --------------
 Hash of config entries for a specific user's ~/.ssh/config. Please check the docs for ssd::config_entry for a list and details of the parameters usable here.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,7 @@ class ssh (
   $sshd_config_key_revocation_list        = undef,
   $sshd_config_authorized_principals_file = undef,
   $sshd_config_allowagentforwarding       = undef,
-  Optional[Array[Stdlib::Host]] $host_aliases = undef,
+  $host_aliases                           = undef,
 ) {
 
   case $::osfamily {


### PR DESCRIPTION
We use IPA for our host registration and authentication. When the SSH module adds the FQDN and the HOSTNAME (without domain suffix) to the global known_hosts, auto-complate with SSH only uses the HOSTNAME.
We want to be able to remove HOSTNAME and only have FQDN and IPADDRESS in the know_host_file.
With this addition the default behaviour stays the same but we have the option to alter the host_alias.

Could you please allow this change?

I didn't change the indentation of the parameters on purpose so that it is easy to see what has changed.