### PR TITLE
add option to enable subsystem sftp in sshd config

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,7 @@ class ssh (
   $sshd_banner_group                          = 'root',
   $sshd_banner_mode                           = '0644',
   $sshd_config_xauth_location                 = 'USE_DEFAULTS',
+  $sshd_enable_subsystem_sftp                 = true,
   $sshd_config_subsystem_sftp                 = 'USE_DEFAULTS',
   $sshd_kerberos_authentication               = undef,
   $sshd_password_authentication               = 'yes',

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -246,7 +246,9 @@ XAuthLocation <%= @sshd_config_xauth_location_real %>
 
 <% end -%>
 # override default of no subsystems
+<% if @sshd_enable_subsystem_sftp -%>
 Subsystem sftp <%= @sshd_config_subsystem_sftp_real %>
+<% end -%>
 
 <% if @sshd_config_ciphers -%>
 Ciphers <%= @sshd_config_ciphers.join(',') %>


### PR DESCRIPTION
It could be handy to have an option to disable or enable the sftp Subsystem in the sshd config . 

https://serverfault.com/questions/653812/enable-ssh-shell-access-but-disable-sftp-access