### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,7 +147,7 @@ class ssh (
       $default_sshd_gssapicleanupcredentials   = 'yes'
       $default_sshd_acceptenv                  = true
       $default_service_hasstatus               = true
-      if versioncmp($::operatingsystemrelease, '7.4') < 0 {
+      if versioncmp($::operatingsystemrelease, '7.4') <= 0 {
         $default_sshd_config_serverkeybits = '1024'
       } else {
         $default_sshd_config_serverkeybits = undef


### PR DESCRIPTION
serverkeybits is deprecated in 7.4 but versioncmp($::operatingsystemrelease, '7.4') < 0 is false for EL 7.4 should be <= 0