### PR TITLE
ServerKeyBits without $::operatingsystemrelease

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,10 +147,14 @@ class ssh (
       $default_sshd_gssapicleanupcredentials   = 'yes'
       $default_sshd_acceptenv                  = true
       $default_service_hasstatus               = true
-      if versioncmp($::operatingsystemrelease, '7.4') < 0 {
-        $default_sshd_config_serverkeybits = '1024'
-      } else {
-        $default_sshd_config_serverkeybits = undef
+      if $::ssh_version =~ /^OpenSSH_/ {
+        if versioncmp($::ssh_version_numeric, '7.6') < 0 {
+          $default_sshd_config_serverkeybits = '1024'
+        } elsif $::ssh_version == "OpenSSH_7.6" {
+          $default_sshd_config_serverkeybits = '1024'
+        } else {
+          $default_sshd_config_serverkeybits = undef
+        }
       }
       $default_sshd_config_hostkey             = [ '/etc/ssh/ssh_host_rsa_key' ]
       $default_sshd_addressfamily              = 'any'


### PR DESCRIPTION
Attempt to fix ServerKeyBits for all OS with OpenSSH, sparing Sun_SSH which might use ServerKeyBits 768, although sensible folks should have already disabled SSHv1. In theory, this should work for both EL and Debian derivatives regardless of the OS version numbering scheme. Covering possibly mythical OpenSSH_7.6 without p1.