### PR TITLE
Allow not exporting SSH keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,9 +808,19 @@ Export node SSH key. Valid values are 'present' and 'absent'.
 
 - *Default*: 'present'
 
+ssh_key_export
+--------------
+
+Export this hosts' SSH key. If you don't use storeconfigs turn this to false to
+silence some useless warnings.
+
+- *Default*: true
+
 ssh_key_import
 --------------
-Import all exported node SSH keys. Valid values are 'true' and 'false'.
+
+Import all exported node SSH keys. Valid values are 'true' and 'false'. If you
+don't use storeconfigs set this to 'false' to silence some useless warnings.
 
 - *Default*: 'true'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,6 +102,7 @@ class ssh (
   $service_hasrestart                         = true,
   $service_hasstatus                          = 'USE_DEFAULTS',
   $ssh_key_ensure                             = 'present',
+  $ssh_key_export                             = true,
   $ssh_key_import                             = true,
   $ssh_key_type                               = 'ssh-rsa',
   $ssh_config_global_known_hosts_file         = '/etc/ssh/ssh_known_hosts',
@@ -1200,11 +1201,13 @@ class ssh (
   else { $host_aliases = [$::hostname, $::ipaddress] }
 
   # export each node's ssh key
-  @@sshkey { $::fqdn :
-    ensure       => $ssh_key_ensure,
-    host_aliases => $host_aliases,
-    type         => $ssh_key_type,
-    key          => $key,
+  if $ssh_key_export {
+    @@sshkey { $::fqdn :
+      ensure       => $ssh_key_ensure,
+      host_aliases => $host_aliases,
+      type         => $ssh_key_type,
+      key          => $key,
+    }
   }
 
   file { 'ssh_known_hosts':


### PR DESCRIPTION
This enables silencing some useless warnings when using Puppet Bolt for example

Signed-off-by: Samuli Seppänen <samuli.seppanen@puppeteers.net>