### PR TITLE
(GH-332) ignore extra lines for ssh_version / ssh_version_numeric

### DIFF
--- a/lib/facter/ssh.rb
+++ b/lib/facter/ssh.rb
@@ -1,7 +1,7 @@
 Facter.add('ssh_version') do
   setcode do
     if Facter::Util::Resolution.which('ssh')
-      Facter::Util::Resolution.exec('ssh -V 2>&1').match(%r{^[A-Za-z0-9._]+})[0]
+      Facter::Util::Resolution.exec('ssh -V 2>&1').match(%r{^[A-Za-z0-9._]+SSH[A-Za-z0-9._]+})[0]
     end
   end
 end

--- a/spec/unit/facter/ssh_spec.rb
+++ b/spec/unit/facter/ssh_spec.rb
@@ -2,14 +2,15 @@ require 'spec_helper'
 
 describe 'Facter::Util::Fact' do
   version_matrix = {
-    'OpenSSH_5.1p1, OpenSSL 0.9.8a 11 Oct 2005' =>                { ssh_version: 'OpenSSH_5.1p1',   ssh_version_numeric: '5.1' },   # SLES 10.4 i586
-    'OpenSSH_5.1p1, OpenSSL 0.9.8j-fips 07 Jan 2009' =>           { ssh_version: 'OpenSSH_5.1p1',   ssh_version_numeric: '5.1' },   # SLES 11.2 x86_64
-    'OpenSSH_5.3p1, OpenSSL 1.0.1e-fips 11 Feb 2013' =>           { ssh_version: 'OpenSSH_5.3p1',   ssh_version_numeric: '5.3' },   # CentOS 6.5 / RedHat 6.7 x86_64
-    'OpenSSH_6.2p2, OpenSSL 0.9.8j-fips 07 Jan 2009' =>           { ssh_version: 'OpenSSH_6.2p2',   ssh_version_numeric: '6.2' },
-    'OpenSSH_6.6.1p1, OpenSSL 0.9.8j-fips 07 Jan 2009' =>         { ssh_version: 'OpenSSH_6.6.1p1', ssh_version_numeric: '6.6.1' }, # SLES 11.4 x86_64
-    'Sun_SSH_1.1, SSH protocols 1.5/2.0, OpenSSL 0x0090700f' =>   { ssh_version: 'Sun_SSH_1.1',     ssh_version_numeric: '1.1' },   # Solaris 9 SPARC
-    'Sun_SSH_1.1.5, SSH protocols 1.5/2.0, OpenSSL 0x0090704f' => { ssh_version: 'Sun_SSH_1.1.5',   ssh_version_numeric: '1.1.5' }, # Solaris 10 SPARC
-    'broken string' =>                                            { ssh_version: 'broken',          ssh_version_numeric: nil },
+    'OpenSSH_5.1p1, OpenSSL 0.9.8a 11 Oct 2005' =>                  { ssh_version: 'OpenSSH_5.1p1',   ssh_version_numeric: '5.1' },   # SLES 10.4 i586
+    'OpenSSH_5.1p1, OpenSSL 0.9.8j-fips 07 Jan 2009' =>             { ssh_version: 'OpenSSH_5.1p1',   ssh_version_numeric: '5.1' },   # SLES 11.2 x86_64
+    'OpenSSH_5.3p1, OpenSSL 1.0.1e-fips 11 Feb 2013' =>             { ssh_version: 'OpenSSH_5.3p1',   ssh_version_numeric: '5.3' },   # CentOS 6.5 / RedHat 6.7 x86_64
+    'OpenSSH_6.2p2, OpenSSL 0.9.8j-fips 07 Jan 2009' =>             { ssh_version: 'OpenSSH_6.2p2',   ssh_version_numeric: '6.2' },
+    'OpenSSH_6.6.1p1, OpenSSL 0.9.8j-fips 07 Jan 2009' =>           { ssh_version: 'OpenSSH_6.6.1p1', ssh_version_numeric: '6.6.1' }, # SLES 11.4 x86_64
+    'Sun_SSH_1.1, SSH protocols 1.5/2.0, OpenSSL 0x0090700f' =>     { ssh_version: 'Sun_SSH_1.1',     ssh_version_numeric: '1.1' },   # Solaris 9 SPARC
+    'Sun_SSH_1.1.5, SSH protocols 1.5/2.0, OpenSSL 0x0090704f' =>   { ssh_version: 'Sun_SSH_1.1.5',   ssh_version_numeric: '1.1.5' }, # Solaris 10 SPARC
+    "linebreak\nOpenSSH_8.0p1, OpenSSL 1.1.1c FIPS  28 May 2019" => { ssh_version: 'OpenSSH_8.0p1',   ssh_version_numeric: '8.0' },   # with extra line
+    'broken string' =>                                              { ssh_version: nil,               ssh_version_numeric: nil },
   }
 
   describe 'ssh_version' do


### PR DESCRIPTION
This patch fixes the described behaviour in issue#332. To find the correct line, it searches for the string `SSH`.
BUT it also changes the result of broken string to become undef instead of the first string. I think this is even better than any random string.
