### PR TITLE
Support Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,7 @@ jobs:
           - "centos-7"
           - "rocky-8"
           - "ubuntu-1804"
+          - "ubuntu-2204"
         puppet:
           - "puppet7"
     env:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ known to work on many, many platforms since its creation in 2010.
  * EL 8
  * Ubuntu 18.04 LTS
  * Ubuntu 20.04 LTS
+ * Ubuntu 22.04 LTS
  * Solaris 10
  * Solaris 11
 

--- a/data/os/Ubuntu/22.04.yaml
+++ b/data/os/Ubuntu/22.04.yaml
@@ -1,0 +1,25 @@
+---
+# Ubuntu 22.04 defaults in alphabetical order per class
+ssh::gss_api_authentication: 'yes'
+ssh::hash_known_hosts: 'yes'
+ssh::include: '/etc/ssh/ssh_config.d/*.conf'
+ssh::packages:
+  - 'openssh-client'
+ssh::send_env:
+  - 'LANG'
+  - 'LC_*'
+
+ssh::server::accept_env:
+  - 'LANG'
+  - 'LC_*'
+ssh::server::kbd_interactive_authentication: 'no'
+ssh::server::include: '/etc/ssh/sshd_config.d/*.conf'
+ssh::server::packages:
+  - 'openssh-server'
+ssh::server::password_authentication: 'yes'
+ssh::server::permit_root_login: 'yes'
+ssh::server::print_motd: 'no'
+ssh::server::service_name: 'ssh'
+ssh::server::subsystem: 'sftp /usr/lib/openssh/sftp-server'
+ssh::server::use_pam: 'yes'
+ssh::server::x11_forwarding: 'yes'

--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     }
   ],

--- a/spec/acceptance/nodesets/ubuntu-2204.yml
+++ b/spec/acceptance/nodesets/ubuntu-2204.yml
@@ -1,0 +1,21 @@
+HOSTS:
+  ubuntu2204:
+    roles:
+      - agent
+    platform: ubuntu-22.04-amd64
+    hypervisor : docker
+    image: ubuntu:22.04
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - "rm -f /etc/dpkg/dpkg.cfg.d/excludes"
+      - 'apt-get install -y wget net-tools locales apt-transport-https ca-certificates'
+      - 'locale-gen en_US.UTF-8'
+    docker_container_name: 'ssh-ubuntu2204'
+CONFIG:
+  log_level: debug
+  type: foss
+ssh:
+  password: root
+  auth_methods: ["password"]
+

--- a/spec/fixtures/testing/Ubuntu-22.04_ssh_config
+++ b/spec/fixtures/testing/Ubuntu-22.04_ssh_config
@@ -1,0 +1,11 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+# See https://man.openbsd.org/ssh_config for more info
+
+Host *
+  GSSAPIAuthentication yes
+  HashKnownHosts yes
+  Include /etc/ssh/ssh_config.d/*.conf
+  SendEnv LANG
+  SendEnv LC_*

--- a/spec/fixtures/testing/Ubuntu-22.04_sshd_config
+++ b/spec/fixtures/testing/Ubuntu-22.04_sshd_config
@@ -1,0 +1,15 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+# See https://man.openbsd.org/sshd_config for more info
+
+AcceptEnv LANG
+AcceptEnv LC_*
+Include /etc/ssh/sshd_config.d/*.conf
+KbdInteractiveAuthentication no
+PasswordAuthentication yes
+PermitRootLogin yes
+PrintMotd no
+Subsystem sftp /usr/lib/openssh/sftp-server
+UsePAM yes
+X11Forwarding yes

--- a/spec/fixtures/untouched/Ubuntu-22.04_ssh_config
+++ b/spec/fixtures/untouched/Ubuntu-22.04_ssh_config
@@ -1,0 +1,53 @@
+
+# This is the ssh client system-wide configuration file.  See
+# ssh_config(5) for more information.  This file provides defaults for
+# users, and the values can be changed in per-user configuration files
+# or on the command line.
+
+# Configuration data is parsed as follows:
+#  1. command line options
+#  2. user-specific file
+#  3. system-wide file
+# Any configuration value is only changed the first time it is set.
+# Thus, host-specific definitions should be at the beginning of the
+# configuration file, and defaults at the end.
+
+# Site-wide defaults for some commonly used options.  For a comprehensive
+# list of available options, their meanings and defaults, please see the
+# ssh_config(5) man page.
+
+Include /etc/ssh/ssh_config.d/*.conf
+
+Host *
+#   ForwardAgent no
+#   ForwardX11 no
+#   ForwardX11Trusted yes
+#   PasswordAuthentication yes
+#   HostbasedAuthentication no
+#   GSSAPIAuthentication no
+#   GSSAPIDelegateCredentials no
+#   GSSAPIKeyExchange no
+#   GSSAPITrustDNS no
+#   BatchMode no
+#   CheckHostIP yes
+#   AddressFamily any
+#   ConnectTimeout 0
+#   StrictHostKeyChecking ask
+#   IdentityFile ~/.ssh/id_rsa
+#   IdentityFile ~/.ssh/id_dsa
+#   IdentityFile ~/.ssh/id_ecdsa
+#   IdentityFile ~/.ssh/id_ed25519
+#   Port 22
+#   Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc
+#   MACs hmac-md5,hmac-sha1,umac-64@openssh.com
+#   EscapeChar ~
+#   Tunnel no
+#   TunnelDevice any:any
+#   PermitLocalCommand no
+#   VisualHostKey no
+#   ProxyCommand ssh -q -W %h:%p gateway.example.com
+#   RekeyLimit 1G 1h
+#   UserKnownHostsFile ~/.ssh/known_hosts.d/%k
+    SendEnv LANG LC_*
+    HashKnownHosts yes
+    GSSAPIAuthentication yes

--- a/spec/fixtures/untouched/Ubuntu-22.04_sshd_config
+++ b/spec/fixtures/untouched/Ubuntu-22.04_sshd_config
@@ -1,0 +1,123 @@
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+Include /etc/ssh/sshd_config.d/*.conf
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+PermitRootLogin yes
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# Expect .ssh/authorized_keys2 to be disregarded by default in future.
+#AuthorizedKeysFile     .ssh/authorized_keys .ssh/authorized_keys2
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+#PasswordAuthentication yes
+#PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+KbdInteractiveAuthentication no
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the KbdInteractiveAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via KbdInteractiveAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and KbdInteractiveAuthentication to 'no'.
+UsePAM yes
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+X11Forwarding yes
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+PrintMotd no
+#PrintLastLog yes
+#TCPKeepAlive yes
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+# override default of no subsystems
+Subsystem sftp  /usr/lib/openssh/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#       X11Forwarding no
+#       AllowTcpForwarding no
+#       PermitTTY no
+#       ForceCommand cvs server
+PasswordAuthentication yes


### PR DESCRIPTION
Adds support for Ubuntu 22.04. Updated for v4.0.0.
<details>
<summary>Old text which is not relevant anymore</summary>
Default configuration in Ubuntu 22.04 is chmod 0644 on /etc/ssh/sshd_config. Defaults on 22.04 (compared to 20.04):
* GSSAPICleanupCredentials is unset
* UseDNS is set to 'no'

It also contains a small set of spec test fixes and ensure https is used for all repositories in .fixtures.yaml

However! What are our expected default values for operating systems? The OS defaults or some module specified defaults?

Difference between default ssh configuration and Puppet. How should we proceed?
```
-Host *
+# Host *                            
 #   ForwardAgent no    
 #   ForwardX11 no
-#   ForwardX11Trusted yes
-#   PasswordAuthentication yes             
+#   RhostsRSAAuthentication no                                                        
+#   RSAAuthentication yes                                        
+   PasswordAuthentication yes     
+   PubkeyAuthentication yes
 #   HostbasedAuthentication no
-#   GSSAPIAuthentication no                                                                                                                                                                                                            
-#   GSSAPIDelegateCredentials no                  
-#   GSSAPIKeyExchange no                                          
-#   GSSAPITrustDNS no                                                             
 #   BatchMode no  
 #   CheckHostIP yes                                                   
 #   AddressFamily any                     
 #   ConnectTimeout 0
 #   StrictHostKeyChecking ask
-#   IdentityFile ~/.ssh/id_rsa
-#   IdentityFile ~/.ssh/id_dsa
-#   IdentityFile ~/.ssh/id_ecdsa
-#   IdentityFile ~/.ssh/id_ed25519
+#   IdentityFile ~/.ssh/identity
+   IdentityFile ~/.ssh/id_rsa
+   IdentityFile ~/.ssh/id_dsa
 #   Port 22
-#   Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc
-#   MACs hmac-md5,hmac-sha1,umac-64@openssh.com
+   Protocol 2
+#   Cipher 3des
+#   Ciphers aes128-cbc,3des-cbc,blowfish-cbc,cast128-cbc,arcfour,aes192-cbc,aes256-cbc
 #   EscapeChar ~
 #   Tunnel no
 #   TunnelDevice any:any
 #   PermitLocalCommand no
-#   VisualHostKey no
-#   ProxyCommand ssh -q -W %h:%p gateway.example.com
-#   RekeyLimit 1G 1h
-#   UserKnownHostsFile ~/.ssh/known_hosts.d/%k
-    SendEnv LANG LC_*
-    HashKnownHosts yes
-    GSSAPIAuthentication yes
+#   HashKnownHosts no
+   HashKnownHosts yes
+   GlobalKnownHostsFile /etc/ssh/ssh_known_hosts
+Host *
+#  GSSAPIAuthentication yes
+  GSSAPIAuthentication yes
+GSSAPIDelegateCredentials yes
+# If this option is set to yes then remote X11 clients will have full access
+# to the original X11 display. As virtually no X11 client supports the untrusted
+# mode correctly we set this to yes.
+  ForwardX11Trusted yes
+  UseRoaming no
+  ServerAliveInterval 240
+# Send locale-related environment variables
+  SendEnv LANG LANGUAGE LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+  SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+  SendEnv LC_IDENTIFICATION LC_ALL
+  SendEnv XMODIFIERS
```
</details>