### PR TITLE
Fix Subsystem sftp and serverkeybits on SLES 12

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -186,9 +186,12 @@ class ssh (
         'x86_64': {
           if ($::operatingsystem == 'SLES') {
             case $::operatingsystemrelease {
-              /15\./: {
+              /^(12|15)\./: {
                 $default_sshd_config_subsystem_sftp = '/usr/lib/ssh/sftp-server'
-                $default_sshd_config_serverkeybits  = undef
+                $default_sshd_config_serverkeybits  = $::operatingsystemrelease ? {
+                  /^12/   => '1024',
+                  default => undef,
+                }
               }
               default: {
                 $default_sshd_config_subsystem_sftp = '/usr/lib64/ssh/sftp-server'


### PR DESCRIPTION
This pull request restores path to subsystem sftp binary on SLES 12. It also restores the previous configuration where ServerKeyBits are set to 1024.

```
# cat /etc/os-release 
NAME="SLES"
VERSION="12-SP5"
...
# ls -l /usr/lib64/ssh/sftp-server
ls: cannot access '/usr/lib64/ssh/sftp-server': No such file or directory
# ls -l /usr/lib/ssh/sftp-server
-rwxr-xr-x 1 root root 445712 Nov 26  2021 /usr/lib/ssh/sftp-server
```