### PR TITLE
ssh::server::host_certificate should be multi-value

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -499,7 +499,7 @@ class ssh::server (
   Optional[Array[String[1]]] $hostbased_accepted_algorithms = undef,
   Optional[Ssh::Yes_no] $hostbased_authentication = undef,
   Optional[Ssh::Yes_no] $hostbased_uses_name_from_packet_only = undef,
-  Optional[String[1]] $host_certificate = undef,
+  Optional[Array[String[1]]] $host_certificate = undef,
   Optional[Array[String[1]]] $host_key = undef,
   Optional[String[1]] $host_key_agent = undef,
   Optional[Array[String[1]]] $host_key_algorithms = undef,

--- a/spec/classes/server_data_types_spec.rb
+++ b/spec/classes/server_data_types_spec.rb
@@ -15,7 +15,7 @@ describe 'ssh::server' do
       'Array of strings (optional)' => {
         name:     ['accept_env', 'allow_groups', 'allow_users', 'authentication_methods',
                    'authorized_keys_file', 'ca_signature_algorithms', 'ciphers', 'custom',
-                   'deny_groups', 'deny_users', 'host_key', 'host_key_algorithms',
+                   'deny_groups', 'deny_users', 'host_certificate', 'host_key', 'host_key_algorithms',
                    'hostbased_accepted_algorithms', 'kex_algorithms', 'listen_address', 'macs',
                    'packages', 'permit_listen', 'permit_open', 'pubkey_accepted_algorithms',
                    'set_env'],
@@ -63,7 +63,7 @@ describe 'ssh::server' do
         name:     ['authorized_keys_command', 'authorized_keys_command_user',
                    'authorized_principals_command', 'authorized_principals_command_user',
                    'authorized_principals_file', 'banner', 'banner_content', 'chroot_directory',
-                   'force_command', 'host_certificate', 'host_key_agent', 'ip_qos', 'log_verbose',
+                   'force_command', 'host_key_agent', 'ip_qos', 'log_verbose',
                    'max_startups', 'permit_user_environment', 'per_source_max_startups',
                    'per_source_net_block_size', 'pid_file', 'rdomain', 'rekey_limit', 'revoked_keys',
                    'subsystem', 'trusted_user_ca_keys', 'version_addendum', 'xauth_location'],

--- a/spec/classes/server_params_spec.rb
+++ b/spec/classes/server_params_spec.rb
@@ -46,7 +46,7 @@ describe 'ssh::server' do
     'hostbased_accepted_algorithms'        => { str: 'HostbasedAcceptedAlgorithms',      val: [['ssh-ed25519'], ['ssh-ed25519', 'rsa-sha2-512']], sep: ',', },
     'hostbased_authentication'             => { str: 'HostbasedAuthentication',          val: ['yes', 'no'], },
     'hostbased_uses_name_from_packet_only' => { str: 'HostbasedUsesNameFromPacketOnly',  val: ['yes', 'no'], },
-    'host_certificate'                     => { str: 'HostCertificate',                  val: ['/test/ing', '/test/ing2'], },
+    'host_certificate'                     => { str: 'HostCertificate',                  val: [['/test/ing'], ['/test/ing1', '/test/ing2']], sep: "\nHostCertificate ", },
     'host_key'                             => { str: 'HostKey',                          val: [['/test/ing'], ['/test/ing1', '/test/ing2']], sep: "\nHostKey ", },
     'host_key_agent'                       => { str: 'HostKeyAgent',                     val: ['/test/ing', '/test/ing2'], },
     'host_key_algorithms'                  => { str: 'HostKeyAlgorithms',                val: [['ssh-ed25519'], ['ssh-ed25519', 'rsa-sha2-512']], sep: ',', },

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -111,7 +111,9 @@ HostbasedAuthentication <%= @hostbased_authentication %>
 HostbasedUsesNameFromPacketOnly <%= @hostbased_uses_name_from_packet_only %>
 <% end -%>
 <% if @host_certificate != nil -%>
-HostCertificate <%= @host_certificate %>
+<%   @host_certificate.each do |v| -%>
+HostCertificate <%= v %>
+<%   end -%>
 <% end -%>
 <% if @host_key != nil -%>
 <%   @host_key.each do |v| -%>


### PR DESCRIPTION
Parameter documentation implies that it should have been multi-value to begin with, and sshd_config accepts multiple HostCertificate directives, usually to handle different key types (e.g., RSA, ECDSA, and ED25519).