### PR TITLE
Add support for Debian 12 and Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,8 +58,10 @@ jobs:
           - "el8"
           - "el9"
           - "debian-11"
+          - "debian-12"
           - "ubuntu-2004"
           - "ubuntu-2204"
+          - "ubuntu-2404"
         puppet:
           - "puppet7"
           - "puppet8"

--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ known to work on many, many platforms since its creation in 2010.
  * Archlinux
  * Debian 10
  * Debian 11
+ * Debian 12
  * EL 7
  * EL 8
  * EL 9
  * Ubuntu 18.04 LTS
  * Ubuntu 20.04 LTS
  * Ubuntu 22.04 LTS
+ * Ubuntu 24.04 LTS
  * Solaris 10
  * Solaris 11
 

--- a/data/os/Debian/12.yaml
+++ b/data/os/Debian/12.yaml
@@ -1,0 +1,24 @@
+---
+# Debian 12 defaults in alphabetical order per class
+ssh::gss_api_authentication: 'yes'
+ssh::hash_known_hosts: 'yes'
+ssh::host: '*'
+ssh::include: '/etc/ssh/ssh_config.d/*.conf'
+ssh::packages:
+  - 'openssh-client'
+ssh::send_env:
+  - 'LANG'
+  - 'LC_*'
+
+ssh::server::accept_env:
+  - 'LANG'
+  - 'LC_*'
+ssh::server::kbd_interactive_authentication: 'no'
+ssh::server::include: '/etc/ssh/sshd_config.d/*.conf'
+ssh::server::packages:
+  - 'openssh-server'
+ssh::server::print_motd: 'no'
+ssh::server::service_name: 'ssh'
+ssh::server::subsystem: 'sftp /usr/lib/openssh/sftp-server'
+ssh::server::use_pam: 'yes'
+ssh::server::x11_forwarding: 'yes'

--- a/data/os/Ubuntu/24.04.yaml
+++ b/data/os/Ubuntu/24.04.yaml
@@ -1,0 +1,25 @@
+---
+# Ubuntu 24.04 defaults in alphabetical order per class
+ssh::gss_api_authentication: 'yes'
+ssh::hash_known_hosts: 'yes'
+ssh::host: '*'
+ssh::include: '/etc/ssh/ssh_config.d/*.conf'
+ssh::packages:
+  - 'openssh-client'
+ssh::send_env:
+  - 'LANG'
+  - 'LC_*'
+
+ssh::server::accept_env:
+  - 'LANG'
+  - 'LC_*'
+ssh::server::kbd_interactive_authentication: 'no'
+ssh::server::include: '/etc/ssh/sshd_config.d/*.conf'
+ssh::server::packages:
+  - 'openssh-server'
+ssh::server::password_authentication: 'yes'
+ssh::server::print_motd: 'no'
+ssh::server::service_name: 'ssh'
+ssh::server::subsystem: 'sftp /usr/lib/openssh/sftp-server'
+ssh::server::use_pam: 'yes'
+ssh::server::x11_forwarding: 'yes'

--- a/metadata.json
+++ b/metadata.json
@@ -43,7 +43,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "11"
+        "11",
+        "12"
       ]
     },
     {
@@ -86,7 +87,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "20.04",
-        "22.04"
+        "22.04",
+        "24.04"
       ]
     }
   ],

--- a/spec/acceptance/nodesets/debian-12.yml
+++ b/spec/acceptance/nodesets/debian-12.yml
@@ -1,0 +1,27 @@
+HOSTS:
+  debian12:
+    roles:
+      - agent
+    platform: debian-12-amd64
+    hypervisor: docker
+    image: debian:12
+    docker_preserve_image: true
+    docker_cmd:
+      - '/sbin/init'
+    docker_image_commands:
+      - 'apt-get install -y wget net-tools systemd-sysv locales apt-transport-https ca-certificates'
+      - 'echo "LC_ALL=en_US.UTF-8" >> /etc/environment'
+      - 'echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen'
+      - 'echo "LANG=en_US.UTF-8" > /etc/locale.conf'
+      - 'locale-gen en_US.UTF-8'
+    docker_env:
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
+    docker_container_name: 'ssh-debian12'
+CONFIG:
+  log_level: debug
+  type: foss
+ssh:
+  password: root
+  auth_methods: ["password"]

--- a/spec/acceptance/nodesets/ubuntu-2404.yml
+++ b/spec/acceptance/nodesets/ubuntu-2404.yml
@@ -1,0 +1,24 @@
+HOSTS:
+  ubuntu2404:
+    roles:
+      - agent
+    platform: ubuntu-24.04-amd64
+    hypervisor : docker
+    image: ubuntu:24.04
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - "rm -f /etc/dpkg/dpkg.cfg.d/excludes"
+      - 'apt-get install -y wget net-tools iproute2 locales apt-transport-https ca-certificates'
+      - 'locale-gen en_US.UTF-8'
+    docker_env:
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
+    docker_container_name: 'ssh-ubuntu2404'
+CONFIG:
+  log_level: debug
+  type: foss
+ssh:
+  password: root
+  auth_methods: ["password"]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,7 +22,7 @@ describe 'ssh' do
     when %r{Debian-10}, %r{Ubuntu-18.04}
       packages_client = ['openssh-client']
       packages_server = ['openssh-server']
-    when %r{Debian-11}, %r{Ubuntu-(20.04|22.04)}
+    when %r{Debian-1[12]}, %r{Ubuntu-(20.04|22.04|24.04)}
       packages_client = ['openssh-client']
       packages_server = ['openssh-server']
       include_dir     = '/etc/ssh/ssh_config.d'

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -39,7 +39,7 @@ describe 'ssh::server' do
         packages          = ['openssh-server']
         service_hasstatus = true
         service_name      = 'ssh'
-      when %r{Debian-11}, %r{Ubuntu-(20.04|22.04)}
+      when %r{Debian-1[12]}, %r{Ubuntu-(20.04|22.04|24.04)}
         config_mode       = '0600'
         packages          = ['openssh-server']
         service_hasstatus = true

--- a/spec/fixtures/testing/Debian-12_ssh_config
+++ b/spec/fixtures/testing/Debian-12_ssh_config
@@ -1,0 +1,11 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+# See https://man.openbsd.org/ssh_config for more info
+
+Host *
+  GSSAPIAuthentication yes
+  HashKnownHosts yes
+  Include /etc/ssh/ssh_config.d/*.conf
+  SendEnv LANG
+  SendEnv LC_*

--- a/spec/fixtures/testing/Debian-12_sshd_config
+++ b/spec/fixtures/testing/Debian-12_sshd_config
@@ -1,0 +1,13 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+# See https://man.openbsd.org/sshd_config for more info
+
+Include /etc/ssh/sshd_config.d/*.conf
+AcceptEnv LANG
+AcceptEnv LC_*
+KbdInteractiveAuthentication no
+PrintMotd no
+Subsystem sftp /usr/lib/openssh/sftp-server
+UsePAM yes
+X11Forwarding yes

--- a/spec/fixtures/testing/Ubuntu-24.04_ssh_config
+++ b/spec/fixtures/testing/Ubuntu-24.04_ssh_config
@@ -1,0 +1,11 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+# See https://man.openbsd.org/ssh_config for more info
+
+Host *
+  GSSAPIAuthentication yes
+  HashKnownHosts yes
+  Include /etc/ssh/ssh_config.d/*.conf
+  SendEnv LANG
+  SendEnv LC_*

--- a/spec/fixtures/testing/Ubuntu-24.04_sshd_config
+++ b/spec/fixtures/testing/Ubuntu-24.04_sshd_config
@@ -1,0 +1,14 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+# See https://man.openbsd.org/sshd_config for more info
+
+Include /etc/ssh/sshd_config.d/*.conf
+AcceptEnv LANG
+AcceptEnv LC_*
+KbdInteractiveAuthentication no
+PasswordAuthentication yes
+PrintMotd no
+Subsystem sftp /usr/lib/openssh/sftp-server
+UsePAM yes
+X11Forwarding yes


### PR DESCRIPTION
Simple copy of Debian 11 and Ubuntu 22.04 config. Saw no reason to change any of the defaults. Definitely better than the global defaults...

Fixes: #427