### PR TITLE
Adding UseRoaming parameter

### DIFF
--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -281,6 +281,9 @@ Host <%= @host %>
 <% if @update_host_keys != nil -%>
   UpdateHostKeys <%= @update_host_keys %>
 <% end -%>
+<% if @use_roaming != nil -%>
+  UseRoaming <%= @use_roaming %>
+<% end -%>
 <% if @user != nil -%>
   User <%= @user %>
 <% end -%>


### PR DESCRIPTION
It looks like the UseRoaming parameter was removed in the v4 rewrite, commit a55f64c, and not added back in. Sorry if this was done on purpose and I'm missing context. There could be other parameters in the same boat too but this is the only one I noticed.