### PR TITLE
Remove 18.04 from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ known to work on many, many platforms since its creation in 2010.
  * EL 7
  * EL 8
  * EL 9
- * Ubuntu 18.04 LTS
  * Ubuntu 20.04 LTS
  * Ubuntu 22.04 LTS
  * Ubuntu 24.04 LTS


### PR DESCRIPTION
As 18.04 was dropped in https://github.com/ghoneycutt/puppet-module-ssh/pull/417