### PR TITLE
Add support for Debian 13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,7 @@ jobs:
           - "el9"
           - "debian-11"
           - "debian-12"
+          - "debian-13"
           - "ubuntu-2004"
           - "ubuntu-2204"
           - "ubuntu-2404"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ known to work on many, many platforms since its creation in 2010.
  * Debian 10
  * Debian 11
  * Debian 12
+ * Debian 13
  * EL 7
  * EL 8
  * EL 9

--- a/data/os/Debian/13.yaml
+++ b/data/os/Debian/13.yaml
@@ -1,0 +1,24 @@
+---
+# Debian 13 defaults in alphabetical order per class
+ssh::gss_api_authentication: 'yes'
+ssh::hash_known_hosts: 'yes'
+ssh::host: '*'
+ssh::include: '/etc/ssh/ssh_config.d/*.conf'
+ssh::packages:
+  - 'openssh-client'
+ssh::send_env:
+  - 'LANG'
+  - 'LC_*'
+
+ssh::server::accept_env:
+  - 'LANG'
+  - 'LC_*'
+ssh::server::kbd_interactive_authentication: 'no'
+ssh::server::include: '/etc/ssh/sshd_config.d/*.conf'
+ssh::server::packages:
+  - 'openssh-server'
+ssh::server::print_motd: 'no'
+ssh::server::service_name: 'ssh'
+ssh::server::subsystem: 'sftp /usr/lib/openssh/sftp-server'
+ssh::server::use_pam: 'yes'
+ssh::server::x11_forwarding: 'yes'

--- a/metadata.json
+++ b/metadata.json
@@ -44,7 +44,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "11",
-        "12"
+        "12",
+        "13"
       ]
     },
     {

--- a/spec/acceptance/nodesets/debian-13.yml
+++ b/spec/acceptance/nodesets/debian-13.yml
@@ -1,0 +1,27 @@
+HOSTS:
+  debian13:
+    roles:
+      - agent
+    platform: debian-13-amd64
+    hypervisor: docker
+    image: debian:13
+    docker_preserve_image: true
+    docker_cmd:
+      - '/sbin/init'
+    docker_image_commands:
+      - 'apt-get install -y wget net-tools systemd-sysv locales apt-transport-https ca-certificates'
+      - 'echo "LC_ALL=en_US.UTF-8" >> /etc/environment'
+      - 'echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen'
+      - 'echo "LANG=en_US.UTF-8" > /etc/locale.conf'
+      - 'locale-gen en_US.UTF-8'
+    docker_env:
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
+    docker_container_name: 'ssh-debian13'
+CONFIG:
+  log_level: debug
+  type: foss
+ssh:
+  password: root
+  auth_methods: ["password"]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,7 +22,7 @@ describe 'ssh' do
     when %r{Debian-10}, %r{Ubuntu-18.04}
       packages_client = ['openssh-client']
       packages_server = ['openssh-server']
-    when %r{Debian-1[12]}, %r{Ubuntu-(20.04|22.04|24.04)}
+    when %r{Debian-1[123]}, %r{Ubuntu-(20.04|22.04|24.04)}
       packages_client = ['openssh-client']
       packages_server = ['openssh-server']
       include_dir     = '/etc/ssh/ssh_config.d'

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -39,7 +39,7 @@ describe 'ssh::server' do
         packages          = ['openssh-server']
         service_hasstatus = true
         service_name      = 'ssh'
-      when %r{Debian-1[12]}, %r{Ubuntu-(20.04|22.04|24.04)}
+      when %r{Debian-1[123]}, %r{Ubuntu-(20.04|22.04|24.04)}
         config_mode       = '0600'
         packages          = ['openssh-server']
         service_hasstatus = true

--- a/spec/fixtures/testing/Debian-13_ssh_config
+++ b/spec/fixtures/testing/Debian-13_ssh_config
@@ -1,0 +1,13 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+# See https://man.openbsd.org/ssh_config for more info
+
+Host *
+  GSSAPIAuthentication yes
+  HashKnownHosts yes
+  Include /etc/ssh/ssh_config.d/*.conf
+  SendEnv LANG
+  SendEnv LC_*
+  SendEnv COLORTERM
+  SendEnv NO_COLOR

--- a/spec/fixtures/testing/Debian-13_sshd_config
+++ b/spec/fixtures/testing/Debian-13_sshd_config
@@ -1,0 +1,15 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+# See https://man.openbsd.org/sshd_config for more info
+
+Include /etc/ssh/sshd_config.d/*.conf
+AcceptEnv LANG
+AcceptEnv LC_*
+AcceptEnv COLORTERM
+AcceptEnv NO_COLOR
+KbdInteractiveAuthentication no
+PrintMotd no
+Subsystem sftp /usr/lib/openssh/sftp-server
+UsePAM yes
+X11Forwarding yes


### PR DESCRIPTION
Debian v13 AKA trixie was released on 2025-08-09 as Debian's new stable release.

The default `/etc/ssh/ssh_config` + `/etc/ssh/sshd_config` on Debian 13 are similar to what's present on Debian 12, only `AcceptEnv` now also includes `COLORTERM` + `NO_COLOR`.

FTR: I had the main changes laying around since some weeks for testing internally, only now found time to provide it as PR. Also only now noticed that @Arakmar came up with https://github.com/ghoneycutt/puppet-module-ssh/pull/440/ already just two days ago. :) Not sure which approach is better and easier to maintain (given that different Debian releases ship different defaults, do we want to care?), feel free to drop or take from my PR whatever is needed.