### PR TITLE
Allow puppetlabs-sshkeys_core 3.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/sshkeys_core",
-      "version_requirement": ">= 2.3.0 < 3.0.0"
+      "version_requirement": ">= 2.3.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Update `metadata.json` to allow `puppetlabs-sshkeys_core` 3.x.

Fixes #444