### PR TITLE
(ISSUE-437) ChallengeResponseAuthentication cannot be reset

### DIFF
--- a/data/os/Solaris/11.yaml
+++ b/data/os/Solaris/11.yaml
@@ -8,11 +8,11 @@ ssh::packages:
 
 ssh::server::allow_tcp_forwarding: 'yes'
 ssh::server::banner: 'none'
+ssh::server::challenge_response_authentication: 'yes'
 ssh::server::client_alive_count_max: 3
 ssh::server::client_alive_interval: 0
 ssh::server::config_mode: '0644'
 ssh::server::custom:
-  - 'ChallengeResponseAuthentication yes'
   - 'GSSAPIKeyExchange yes'
   - 'PAMAuthenticationViaKBDInt yes'
   - 'ServerKeyBits 768'

--- a/spec/fixtures/testing/Solaris-11_sshd_config
+++ b/spec/fixtures/testing/Solaris-11_sshd_config
@@ -5,6 +5,7 @@
 
 AllowTcpForwarding yes
 Banner none
+ChallengeResponseAuthentication yes
 ClientAliveCountMax 3
 ClientAliveInterval 0
 GSSAPIAuthentication yes
@@ -23,7 +24,6 @@ SyslogFacility AUTH
 X11Forwarding yes
 X11UseLocalhost yes
 XAuthLocation /usr/openwin/bin/xauth
-ChallengeResponseAuthentication yes
 GSSAPIKeyExchange yes
 PAMAuthenticationViaKBDInt yes
 ServerKeyBits 768


### PR DESCRIPTION
ChallengeResponseAuthentication is being set with the 'custom' parameter. Without this patch, one cannot set this to 'no'.